### PR TITLE
Fix tutor form normalization and request tutor display labels

### DIFF
--- a/src/app/(admin)/request-tutor/TutorsList.tsx
+++ b/src/app/(admin)/request-tutor/TutorsList.tsx
@@ -2,9 +2,8 @@
 
 import DataTable, { Column } from "@/components/tables/DataTable";
 import { TABLE_CONFIG } from "@/configs/table";
-import {
-  useFetchRequestForTutorsQuery,
-} from "@/store/api/splits/request-tutor";
+import { useFetchGradesQuery } from "@/store/api/splits/grades";
+import { useFetchRequestForTutorsQuery } from "@/store/api/splits/request-tutor";
 import { RequestTutors } from "@/types/response-types";
 import { useMemo, useState } from "react";
 import { AssignTutorDialog } from "./assignTutor";
@@ -21,10 +20,22 @@ export default function RequestForTutorsList() {
     limit,
     sortBy: "createdAt:desc",
   });
+  const { data: gradesData, isFetching: isFetchingGrades } =
+    useFetchGradesQuery({
+      page: 1,
+      limit: 10000,
+    });
 
   const tutors: RequestTutors[] = data?.results || [];
   const totalPages = data?.totalPages || 1;
   const totalResults = data?.totalResults || tutors.length;
+  const gradeTitleById = useMemo(
+    () =>
+      new Map(
+        (gradesData?.results || []).map((grade) => [grade.id, grade.title]),
+      ),
+    [gradesData?.results],
+  );
 
   const handlePageChange = (newPage: number) => setPage(newPage);
 
@@ -40,12 +51,39 @@ export default function RequestForTutorsList() {
   const getSafeTutorBlocks = (value: RequestTutors["tutors"]) =>
     Array.isArray(value) ? value : [];
 
+  const getGradeDisplayValue = (grade: unknown) => {
+    if (grade && typeof grade === "object") {
+      const gradeRecord = grade as {
+        id?: string;
+        title?: string;
+        name?: string;
+      };
+      return getSafeValue(
+        gradeRecord.title || gradeRecord.name || gradeRecord.id,
+        "",
+      );
+    }
+
+    const gradeId = getSafeValue(grade, "");
+    if (!gradeId) {
+      return "";
+    }
+
+    const gradeTitle = gradeTitleById.get(gradeId);
+    if (gradeTitle) {
+      return gradeTitle;
+    }
+
+    return isFetchingGrades ? "Loading grade..." : "Unknown grade";
+  };
+
   const columns = useMemo<Column<RequestTutors>[]>(
     () => [
       {
         key: "name",
         header: "Full Name",
-        className: "min-w-[150px] max-w-[250px] truncate overflow-hidden sticky left-0 z-20 bg-white dark:bg-gray-900",
+        className:
+          "min-w-[150px] max-w-[250px] truncate overflow-hidden sticky left-0 z-20 bg-white dark:bg-gray-900",
         render: (row: RequestTutors) => (
           <span
             title={row.name || "No name"}
@@ -85,12 +123,17 @@ export default function RequestForTutorsList() {
       {
         key: "grade",
         header: "Grade",
-        className: "min-w-[120px] max-w-[200px] truncate overflow-hidden",
+        className: "min-w-[280px] max-w-[360px] whitespace-normal",
         render: (row: RequestTutors) => {
-          const safeGrade = getSafeValue(row.grade, "");
+          const safeGrade = getGradeDisplayValue(row.grade);
 
           return safeGrade ? (
-            <span title={safeGrade}>{safeGrade}</span>
+            <span
+              title={safeGrade}
+              className="block whitespace-normal break-words leading-5"
+            >
+              {safeGrade}
+            </span>
           ) : (
             <span className="text-gray-400 italic">No grade</span>
           );
@@ -100,14 +143,16 @@ export default function RequestForTutorsList() {
         key: "view",
         header: "View",
         align: "center",
-        className: "min-w-[80px] max-w-[80px] sticky right-[390px] z-20 bg-white dark:bg-gray-900",
+        className:
+          "min-w-[80px] max-w-[80px] sticky right-[390px] z-20 bg-white dark:bg-gray-900",
         render: (row: RequestTutors) => <ViewTutorRequests tutorId={row.id} />,
       },
       {
         key: "status",
         header: "Change Status",
         align: "center",
-        className: "min-w-[140px] max-w-[140px] sticky right-[250px] z-20 bg-white dark:bg-gray-900",
+        className:
+          "min-w-[140px] max-w-[140px] sticky right-[250px] z-20 bg-white dark:bg-gray-900",
         render: (row: RequestTutors) => (
           <ChangeStatusDialog
             requestId={row.id}
@@ -120,7 +165,8 @@ export default function RequestForTutorsList() {
         key: "assignTutor",
         header: "Assign Tutor",
         align: "center",
-        className: "min-w-[170px] max-w-[170px] sticky right-[80px] z-20 bg-white dark:bg-gray-900",
+        className:
+          "min-w-[170px] max-w-[170px] sticky right-[80px] z-20 bg-white dark:bg-gray-900",
         render: (row: RequestTutors) => (
           <AssignTutorDialog
             row={{
@@ -143,11 +189,12 @@ export default function RequestForTutorsList() {
         key: "delete",
         header: "Delete",
         align: "center",
-        className: "min-w-[80px] max-w-[80px] sticky right-0 z-20 bg-white dark:bg-gray-900",
+        className:
+          "min-w-[80px] max-w-[80px] sticky right-0 z-20 bg-white dark:bg-gray-900",
         render: (row: RequestTutors) => <DeleteTutorRequest tutorId={row.id} />,
       },
     ],
-    [refetch],
+    [gradeTitleById, isFetchingGrades, refetch],
   );
 
   return (

--- a/src/app/(admin)/request-tutor/ViewTutor.tsx
+++ b/src/app/(admin)/request-tutor/ViewTutor.tsx
@@ -11,9 +11,11 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { useFetchGradeByIdQuery } from "@/store/api/splits/grades";
 import { useFetchRequestForTutorsByIdQuery } from "@/store/api/splits/request-tutor";
+import { useFetchSubjectsQuery } from "@/store/api/splits/subjects";
 import { Eye } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 interface ViewTutorProps {
   tutorId: string;
@@ -22,9 +24,40 @@ interface ViewTutorProps {
 export function ViewTutorRequests({ tutorId }: ViewTutorProps) {
   const [open, setOpen] = useState(false);
 
-  const { data: tutor, isLoading } = useFetchRequestForTutorsByIdQuery(tutorId, {
-    skip: !open || !tutorId,
-  });
+  const { data: tutor, isLoading } = useFetchRequestForTutorsByIdQuery(
+    tutorId,
+    {
+      skip: !open || !tutorId,
+    },
+  );
+  const gradeId = typeof tutor?.grade === "string" ? tutor.grade.trim() : "";
+  const isGradeId = /^[a-f\d]{24}$/i.test(gradeId);
+  const { data: grade, isFetching: isFetchingGrade } = useFetchGradeByIdQuery(
+    gradeId,
+    {
+      skip: !open || !isGradeId,
+    },
+  );
+  const { data: subjectsData, isFetching: isFetchingSubjects } =
+    useFetchSubjectsQuery(
+      {
+        page: 1,
+        limit: 10000,
+      },
+      {
+        skip: !open,
+      },
+    );
+  const subjectTitleById = useMemo(
+    () =>
+      new Map(
+        (subjectsData?.results || []).map((subject) => [
+          subject.id,
+          subject.title,
+        ]),
+      ),
+    [subjectsData?.results],
+  );
 
   const displayFieldClass =
     "w-full rounded-md border border-gray-200 bg-gray-50 py-2.5 px-3 text-sm text-gray-800 dark:border-gray-700 dark:bg-gray-700 dark:text-white/90 min-h-[2rem] overflow-auto scrollbar-thin";
@@ -74,6 +107,59 @@ export function ViewTutorRequests({ tutorId }: ViewTutorProps) {
     return "";
   };
 
+  const getGradeDisplayValue = (value: unknown) => {
+    if (value && typeof value === "object") {
+      const gradeRecord = value as {
+        id?: string;
+        title?: string;
+        name?: string;
+      };
+      return getSafeValue(
+        gradeRecord.title || gradeRecord.name || gradeRecord.id,
+        "",
+      );
+    }
+
+    const safeGrade = getSafeValue(value, "");
+    if (!safeGrade) {
+      return "";
+    }
+
+    if (!isGradeId) {
+      return safeGrade;
+    }
+
+    return (
+      grade?.title || (isFetchingGrade ? "Loading grade..." : "Unknown grade")
+    );
+  };
+
+  const getSubjectDisplayValue = (value: unknown) => {
+    if (value && typeof value === "object") {
+      const subjectRecord = value as {
+        id?: string;
+        title?: string;
+        name?: string;
+      };
+      return getSafeValue(
+        subjectRecord.title || subjectRecord.name || subjectRecord.id,
+        "",
+      );
+    }
+
+    const subjectId = getSafeValue(value, "");
+    if (!subjectId) {
+      return "";
+    }
+
+    const subjectTitle = subjectTitleById.get(subjectId);
+    if (subjectTitle) {
+      return subjectTitle;
+    }
+
+    return isFetchingSubjects ? "Loading subject..." : "Unknown subject";
+  };
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
@@ -99,33 +185,41 @@ export function ViewTutorRequests({ tutorId }: ViewTutorProps) {
 
           <div className="grid gap-3">
             <Label>Email</Label>
-            <div className={displayFieldClass}>{getSafeValue(tutor?.email)}</div>
+            <div className={displayFieldClass}>
+              {getSafeValue(tutor?.email)}
+            </div>
           </div>
 
           <div className="grid gap-3">
             <Label>Phone Number</Label>
-            <div className={displayFieldClass}>{getSafeValue(tutor?.phoneNumber)}</div>
+            <div className={displayFieldClass}>
+              {getSafeValue(tutor?.phoneNumber)}
+            </div>
           </div>
 
           <div className="grid gap-3">
             <Label>Medium</Label>
-            <div className={displayFieldClass}>{getSafeValue(tutor?.medium)}</div>
+            <div className={displayFieldClass}>
+              {getSafeValue(tutor?.medium)}
+            </div>
           </div>
 
           <div className="grid gap-3">
             <Label>District / City</Label>
             <div className={displayFieldClass}>
-              {[getSafeValue(tutor?.district, ""), getSafeValue(tutor?.city, "")]
+              {[
+                getSafeValue(tutor?.district, ""),
+                getSafeValue(tutor?.city, ""),
+              ]
                 .filter(Boolean)
-                .join(", ") ||
-                "N/A"}
+                .join(", ") || "N/A"}
             </div>
           </div>
 
           <div className="grid gap-3">
             <Label>Grade</Label>
             <div className={displayFieldClass}>
-              {getSafeValue(tutor?.grade, "") || (
+              {getGradeDisplayValue(tutor?.grade) || (
                 <span className="text-gray-400 italic">No grade</span>
               )}
             </div>
@@ -133,7 +227,9 @@ export function ViewTutorRequests({ tutorId }: ViewTutorProps) {
 
           <div className="grid gap-3">
             <Label>Status</Label>
-            <div className={displayFieldClass}>{getSafeValue(tutor?.status)}</div>
+            <div className={displayFieldClass}>
+              {getSafeValue(tutor?.status)}
+            </div>
           </div>
 
           <div className="grid gap-3">
@@ -141,19 +237,28 @@ export function ViewTutorRequests({ tutorId }: ViewTutorProps) {
             <div className="flex flex-col gap-2">
               {Array.isArray(tutor?.tutors) && tutor.tutors.length ? (
                 tutor.tutors.map((t, idx) => {
-                  const assignedTutorLabel = getAssignedTutorLabel(t.assignedTutor);
+                  const assignedTutorLabel = getAssignedTutorLabel(
+                    t.assignedTutor,
+                  );
 
                   return (
-                    <div key={t._id || idx} className="p-3 border rounded space-y-1 bg-gray-50 dark:bg-gray-700">
+                    <div
+                      key={t._id || idx}
+                      className="p-3 border rounded space-y-1 bg-gray-50 dark:bg-gray-700"
+                    >
                       <div>
                         Subject:{" "}
-                        <span className={tagClass}>{getSafeValue(t.subject)}</span>
+                        <span className={tagClass}>
+                          {getSubjectDisplayValue(t.subject)}
+                        </span>
                       </div>
 
                       {assignedTutorLabel && (
                         <div>
                           Assigned Tutor:{" "}
-                          <span className={`${tagClass} bg-green-100 dark:bg-green-800 text-green-800 dark:text-green-200`}>
+                          <span
+                            className={`${tagClass} bg-green-100 dark:bg-green-800 text-green-800 dark:text-green-200`}
+                          >
                             {assignedTutorLabel}
                           </span>
                         </div>
@@ -161,7 +266,8 @@ export function ViewTutorRequests({ tutorId }: ViewTutorProps) {
 
                       {t.preferredTutorType && (
                         <div>
-                          Preferred Type: <strong>{getSafeValue(t.preferredTutorType)}</strong>
+                          Preferred Type:{" "}
+                          <strong>{getSafeValue(t.preferredTutorType)}</strong>
                         </div>
                       )}
                       <div>

--- a/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
+++ b/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
@@ -32,12 +32,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { useCreateTutorMutation } from "@/store/api/splits/tutors";
 import { getErrorInApiResult } from "@/utils/api";
 import {
   collapseTextSpaces,
   stripLeadingSpaces,
-  trimText,
 } from "@/utils/form-normalizers";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState } from "react";
@@ -250,28 +250,28 @@ export function AddTutor() {
   });
   const academicDetailsRegister = form.register("academicDetails", {
     onBlur: (event) => {
-      setValue("academicDetails", trimText(event.target.value) as string, {
+      setValue("academicDetails", collapseTextSpaces(event.target.value), {
         shouldValidate: true,
       });
     },
   });
   const teachingSummaryRegister = form.register("teachingSummary", {
     onBlur: (event) => {
-      setValue("teachingSummary", trimText(event.target.value) as string, {
+      setValue("teachingSummary", collapseTextSpaces(event.target.value), {
         shouldValidate: true,
       });
     },
   });
   const studentResultsRegister = form.register("studentResults", {
     onBlur: (event) => {
-      setValue("studentResults", trimText(event.target.value) as string, {
+      setValue("studentResults", collapseTextSpaces(event.target.value), {
         shouldValidate: true,
       });
     },
   });
   const sellingPointsRegister = form.register("sellingPoints", {
     onBlur: (event) => {
-      setValue("sellingPoints", trimText(event.target.value) as string, {
+      setValue("sellingPoints", collapseTextSpaces(event.target.value), {
         shouldValidate: true,
       });
     },
@@ -667,7 +667,11 @@ export function AddTutor() {
 
             <div className="grid gap-3">
               <Label htmlFor="academicDetails">Academic Details</Label>
-              <Input id="academicDetails" {...academicDetailsRegister} />
+              <Textarea
+                id="academicDetails"
+                placeholder="Academic Details"
+                {...academicDetailsRegister}
+              />
               {formState.errors.academicDetails && (
                 <p className="text-sm text-red-500">
                   {formState.errors.academicDetails.message}
@@ -677,7 +681,11 @@ export function AddTutor() {
 
             <div className="grid gap-3">
               <Label htmlFor="teachingSummary">Teaching Summary *</Label>
-              <Input id="teachingSummary" {...teachingSummaryRegister} />
+              <Textarea
+                id="teachingSummary"
+                placeholder="Teaching Summary"
+                {...teachingSummaryRegister}
+              />
               {formState.errors.teachingSummary && (
                 <p className="text-sm text-red-500">
                   {formState.errors.teachingSummary.message}
@@ -687,7 +695,11 @@ export function AddTutor() {
 
             <div className="grid gap-3">
               <Label htmlFor="studentResults">Student Results *</Label>
-              <Input id="studentResults" {...studentResultsRegister} />
+              <Textarea
+                id="studentResults"
+                placeholder="Student Results"
+                {...studentResultsRegister}
+              />
               {formState.errors.studentResults && (
                 <p className="text-sm text-red-500">
                   {formState.errors.studentResults.message}
@@ -697,7 +709,11 @@ export function AddTutor() {
 
             <div className="grid gap-3">
               <Label htmlFor="sellingPoints">Selling Points *</Label>
-              <Input id="sellingPoints" {...sellingPointsRegister} />
+              <Textarea
+                id="sellingPoints"
+                placeholder="Selling Points"
+                {...sellingPointsRegister}
+              />
               {formState.errors.sellingPoints && (
                 <p className="text-sm text-red-500">
                   {formState.errors.sellingPoints.message}

--- a/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
+++ b/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
@@ -37,6 +37,7 @@ import { getErrorInApiResult } from "@/utils/api";
 import {
   collapseTextSpaces,
   stripLeadingSpaces,
+  trimText,
 } from "@/utils/form-normalizers";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState } from "react";
@@ -243,6 +244,34 @@ export function AddTutor() {
     },
     onBlur: (event) => {
       setValue("fullName", collapseTextSpaces(event.target.value), {
+        shouldValidate: true,
+      });
+    },
+  });
+  const academicDetailsRegister = form.register("academicDetails", {
+    onBlur: (event) => {
+      setValue("academicDetails", trimText(event.target.value) as string, {
+        shouldValidate: true,
+      });
+    },
+  });
+  const teachingSummaryRegister = form.register("teachingSummary", {
+    onBlur: (event) => {
+      setValue("teachingSummary", trimText(event.target.value) as string, {
+        shouldValidate: true,
+      });
+    },
+  });
+  const studentResultsRegister = form.register("studentResults", {
+    onBlur: (event) => {
+      setValue("studentResults", trimText(event.target.value) as string, {
+        shouldValidate: true,
+      });
+    },
+  });
+  const sellingPointsRegister = form.register("sellingPoints", {
+    onBlur: (event) => {
+      setValue("sellingPoints", trimText(event.target.value) as string, {
         shouldValidate: true,
       });
     },
@@ -638,10 +667,7 @@ export function AddTutor() {
 
             <div className="grid gap-3">
               <Label htmlFor="academicDetails">Academic Details</Label>
-              <Input
-                id="academicDetails"
-                {...form.register("academicDetails")}
-              />
+              <Input id="academicDetails" {...academicDetailsRegister} />
               {formState.errors.academicDetails && (
                 <p className="text-sm text-red-500">
                   {formState.errors.academicDetails.message}
@@ -651,10 +677,7 @@ export function AddTutor() {
 
             <div className="grid gap-3">
               <Label htmlFor="teachingSummary">Teaching Summary *</Label>
-              <Input
-                id="teachingSummary"
-                {...form.register("teachingSummary")}
-              />
+              <Input id="teachingSummary" {...teachingSummaryRegister} />
               {formState.errors.teachingSummary && (
                 <p className="text-sm text-red-500">
                   {formState.errors.teachingSummary.message}
@@ -664,7 +687,7 @@ export function AddTutor() {
 
             <div className="grid gap-3">
               <Label htmlFor="studentResults">Student Results *</Label>
-              <Input id="studentResults" {...form.register("studentResults")} />
+              <Input id="studentResults" {...studentResultsRegister} />
               {formState.errors.studentResults && (
                 <p className="text-sm text-red-500">
                   {formState.errors.studentResults.message}
@@ -674,7 +697,7 @@ export function AddTutor() {
 
             <div className="grid gap-3">
               <Label htmlFor="sellingPoints">Selling Points *</Label>
-              <Input id="sellingPoints" {...form.register("sellingPoints")} />
+              <Input id="sellingPoints" {...sellingPointsRegister} />
               {formState.errors.sellingPoints && (
                 <p className="text-sm text-red-500">
                   {formState.errors.sellingPoints.message}

--- a/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
+++ b/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
@@ -34,6 +34,10 @@ import {
 } from "@/components/ui/select";
 import { useCreateTutorMutation } from "@/store/api/splits/tutors";
 import { getErrorInApiResult } from "@/utils/api";
+import {
+  collapseTextSpaces,
+  stripLeadingSpaces,
+} from "@/utils/form-normalizers";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState } from "react";
 import {
@@ -83,9 +87,6 @@ export function AddTutor() {
     name: "dateOfBirth",
     defaultValue: "",
   }) as string;
-
-
-
 
   // Grades / Subjects state & queries (match client logic)
   const { data: gradesData } = useFetchGradesQuery({ page: 1, limit: 100 });
@@ -232,6 +233,21 @@ export function AddTutor() {
     }
   };
 
+  const fullNameRegister = form.register("fullName", {
+    onChange: (event) => {
+      const cleaned = stripLeadingSpaces(event.target.value);
+      if (cleaned !== event.target.value) {
+        event.target.value = cleaned;
+        setValue("fullName", cleaned, { shouldValidate: true });
+      }
+    },
+    onBlur: (event) => {
+      setValue("fullName", collapseTextSpaces(event.target.value), {
+        shouldValidate: true,
+      });
+    },
+  });
+
   return (
     <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
@@ -252,7 +268,7 @@ export function AddTutor() {
           <div className="grid gap-4 p-3">
             <div className="grid gap-3">
               <Label htmlFor="fullName">Full Name *</Label>
-              <Input id="fullName" {...form.register("fullName")} />
+              <Input id="fullName" {...fullNameRegister} />
               {formState.errors.fullName && (
                 <p className="text-sm text-red-500">
                   {formState.errors.fullName.message}
@@ -669,6 +685,7 @@ export function AddTutor() {
             <div className="grid gap-3 border p-4 rounded-md">
               <Label>Certificates & Qualifications</Label>
               <MultiFileUploader
+                mode="certificate"
                 onUploaded={(items) =>
                   setValue("certificatesAndQualifications", items, {
                     shouldDirty: true,

--- a/src/app/(admin)/tutors/components/add-tutor/schema.ts
+++ b/src/app/(admin)/tutors/components/add-tutor/schema.ts
@@ -1,4 +1,4 @@
-import { normalizeTextSpaces, trimText } from "@/utils/form-normalizers";
+import { normalizeTextSpaces } from "@/utils/form-normalizers";
 import { z } from "zod";
 
 const tutorTypeValues = [
@@ -19,9 +19,9 @@ const classTypeValues = [
   "At Tutor's Place - Group",
 ] as const;
 
-const trimmedTextSchema = z
+const normalizedTextSchema = z
   .string()
-  .transform((value) => trimText(value) as string);
+  .transform((value) => normalizeTextSpaces(value) as string);
 
 // Full form schema
 export const addTutorSchema = z.object({
@@ -157,12 +157,12 @@ export const addTutorSchema = z.object({
     "Poly",
     "Others",
   ]),
-  academicDetails: trimmedTextSchema.pipe(z.string().max(1000)).optional(),
+  academicDetails: normalizedTextSchema.pipe(z.string().max(1000)).optional(),
 
   // Tutor's profile
-  teachingSummary: trimmedTextSchema.pipe(z.string().max(750)),
-  studentResults: trimmedTextSchema.pipe(z.string().max(750)),
-  sellingPoints: trimmedTextSchema.pipe(z.string().max(750)),
+  teachingSummary: normalizedTextSchema.pipe(z.string().max(750)),
+  studentResults: normalizedTextSchema.pipe(z.string().max(750)),
+  sellingPoints: normalizedTextSchema.pipe(z.string().max(750)),
   certificatesAndQualifications: z
     .array(
       z.object({

--- a/src/app/(admin)/tutors/components/add-tutor/schema.ts
+++ b/src/app/(admin)/tutors/components/add-tutor/schema.ts
@@ -1,4 +1,4 @@
-import { normalizeTextSpaces } from "@/utils/form-normalizers";
+import { normalizeTextSpaces, trimText } from "@/utils/form-normalizers";
 import { z } from "zod";
 
 const tutorTypeValues = [
@@ -18,6 +18,10 @@ const classTypeValues = [
   "At Tutor's Place - Individual",
   "At Tutor's Place - Group",
 ] as const;
+
+const trimmedTextSchema = z
+  .string()
+  .transform((value) => trimText(value) as string);
 
 // Full form schema
 export const addTutorSchema = z.object({
@@ -153,12 +157,12 @@ export const addTutorSchema = z.object({
     "Poly",
     "Others",
   ]),
-  academicDetails: z.string().max(1000).optional(),
+  academicDetails: trimmedTextSchema.pipe(z.string().max(1000)).optional(),
 
   // Tutor's profile
-  teachingSummary: z.string().max(750),
-  studentResults: z.string().max(750),
-  sellingPoints: z.string().max(750),
+  teachingSummary: trimmedTextSchema.pipe(z.string().max(750)),
+  studentResults: trimmedTextSchema.pipe(z.string().max(750)),
+  sellingPoints: trimmedTextSchema.pipe(z.string().max(750)),
   certificatesAndQualifications: z
     .array(
       z.object({

--- a/src/app/(admin)/tutors/components/add-tutor/schema.ts
+++ b/src/app/(admin)/tutors/components/add-tutor/schema.ts
@@ -26,12 +26,18 @@ export const addTutorSchema = z.object({
     .regex(/^[A-Za-z\s]+$/, "Full Name can contain letters and spaces only"),
   contactNumber: z
     .string()
+    .min(1, "Contact Number is required")
     .regex(/^[0-9]+$/, "Contact number must contain only numbers")
     .length(10, "Contact number must be exactly 10 digits"),
 
-  email: z.string().email("Email must be valid"),
+  email: z
+    .string()
+    .trim()
+    .min(1, "Email is required")
+    .email("Email must be valid"),
   dateOfBirth: z
     .string()
+    .min(1, "Date of Birth is required")
     .regex(/^\d{4}-\d{2}-\d{2}$/, "Date of Birth must be in YYYY-MM-DD"),
 
   gender: z.enum(["Male", "Female"]),

--- a/src/app/(admin)/tutors/components/add-tutor/schema.ts
+++ b/src/app/(admin)/tutors/components/add-tutor/schema.ts
@@ -1,3 +1,4 @@
+import { normalizeTextSpaces } from "@/utils/form-normalizers";
 import { z } from "zod";
 
 const tutorTypeValues = [
@@ -22,8 +23,16 @@ const classTypeValues = [
 export const addTutorSchema = z.object({
   fullName: z
     .string()
-    .min(1, "Full Name is required")
-    .regex(/^[A-Za-z\s]+$/, "Full Name can contain letters and spaces only"),
+    .transform((value) => normalizeTextSpaces(value) as string)
+    .pipe(
+      z
+        .string()
+        .min(1, "Full Name is required")
+        .regex(
+          /^[A-Za-z\s]+$/,
+          "Full Name can contain letters and spaces only",
+        ),
+    ),
   contactNumber: z
     .string()
     .min(1, "Contact Number is required")

--- a/src/app/(admin)/tutors/components/edit-tutor/EditTutor.tsx
+++ b/src/app/(admin)/tutors/components/edit-tutor/EditTutor.tsx
@@ -38,6 +38,11 @@ import {
   useLazyFetchGradeByIdQuery,
 } from "@/store/api/splits/grades";
 import { getErrorInApiResult } from "@/utils/api";
+import {
+  collapseTextSpaces,
+  normalizeTextSpaces,
+  stripLeadingSpaces,
+} from "@/utils/form-normalizers";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { SquarePen } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
@@ -319,7 +324,7 @@ export function EditTutor({ id }: EditTutorProps) {
   const buildResetValues = (data: typeof tutorData) => {
     if (!data) return {};
     return {
-      fullName: data.fullName || "",
+      fullName: normalizeTextSpaces(data.fullName || "") as string,
       contactNumber: data.contactNumber || "",
       email: data.email || "",
       dateOfBirth: formatDateForForm(data.dateOfBirth),
@@ -328,7 +333,11 @@ export function EditTutor({ id }: EditTutorProps) {
       tutorMediums: data.tutorMediums || [],
       grades: data.grades || [],
       subjects: data.subjects || [],
-      nationality: safeEnumValue(data.nationality, nationalityOptions, "Sri Lankan"),
+      nationality: safeEnumValue(
+        data.nationality,
+        nationalityOptions,
+        "Sri Lankan",
+      ),
       race: safeEnumValue(data.race, raceOptions, "Sinhalese"),
       status: safeEnumValue(
         data.status,
@@ -336,14 +345,24 @@ export function EditTutor({ id }: EditTutorProps) {
         "pending",
       ),
       classType: safeArrayEnumValue(data.classType, classTypeValues),
-      tutoringLevels: safeArrayEnumValue(data.tutoringLevels, tutoringLevelsList),
-      preferredLocations: safeArrayEnumValue(data.preferredLocations, locationOptions),
+      tutoringLevels: safeArrayEnumValue(
+        data.tutoringLevels,
+        tutoringLevelsList,
+      ),
+      preferredLocations: safeArrayEnumValue(
+        data.preferredLocations,
+        locationOptions,
+      ),
       tutorType: safeArrayEnumValue(
         data.tutorType,
         tutorTypeValues,
       ) as UpdateTutorSchema["tutorType"],
       yearsExperience: data.yearsExperience || 0,
-      highestEducation: safeEnumValue(data.highestEducation, educationOptions, "Undergraduate"),
+      highestEducation: safeEnumValue(
+        data.highestEducation,
+        educationOptions,
+        "Undergraduate",
+      ),
       academicDetails: data.academicDetails || "",
       teachingSummary: data.teachingSummary || "",
       studentResults: data.studentResults || "",
@@ -362,7 +381,7 @@ export function EditTutor({ id }: EditTutorProps) {
     if (tutorData && open) {
       reset(buildResetValues(tutorData));
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tutorData, open, reset]);
 
   const handleDialogOpenChange = (isOpen: boolean) => {
@@ -412,6 +431,21 @@ export function EditTutor({ id }: EditTutorProps) {
     }
   };
 
+  const fullNameRegister = form.register("fullName", {
+    onChange: (event) => {
+      const cleaned = stripLeadingSpaces(event.target.value);
+      if (cleaned !== event.target.value) {
+        event.target.value = cleaned;
+        setValue("fullName", cleaned, { shouldValidate: true });
+      }
+    },
+    onBlur: (event) => {
+      setValue("fullName", collapseTextSpaces(event.target.value), {
+        shouldValidate: true,
+      });
+    },
+  });
+
   if (isFetching) {
     return <p>Loading tutor details...</p>;
   }
@@ -456,7 +490,7 @@ export function EditTutor({ id }: EditTutorProps) {
               <Input
                 id="fullName"
                 placeholder="Full Name"
-                {...form.register("fullName")}
+                {...fullNameRegister}
               />
               {formState.errors.fullName && (
                 <p className="text-sm text-red-500">
@@ -718,12 +752,17 @@ export function EditTutor({ id }: EditTutorProps) {
             <div className="grid gap-3 border p-4 rounded-md">
               <Label>Certificates & Qualifications</Label>
               <MultiFileUploader
+                mode="certificate"
                 defaultFiles={tutorData?.certificatesAndQualifications || []}
                 onUploaded={(items) =>
-                  setValue("certificatesAndQualifications" as never, items as never, {
-                    shouldDirty: true,
-                    shouldValidate: true,
-                  })
+                  setValue(
+                    "certificatesAndQualifications" as never,
+                    items as never,
+                    {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    },
+                  )
                 }
               />
               {formState.errors.certificatesAndQualifications && (
@@ -809,8 +848,12 @@ export function EditTutor({ id }: EditTutorProps) {
                     <SelectItem value="Diploma">Diploma</SelectItem>
                     <SelectItem value="Masters">Masters</SelectItem>
                     <SelectItem value="Undergraduate">Undergraduate</SelectItem>
-                    <SelectItem value="Bachelor Degree">Bachelor Degree</SelectItem>
-                    <SelectItem value="Diploma and Professional">Diploma and Professional</SelectItem>
+                    <SelectItem value="Bachelor Degree">
+                      Bachelor Degree
+                    </SelectItem>
+                    <SelectItem value="Diploma and Professional">
+                      Diploma and Professional
+                    </SelectItem>
                     <SelectItem value="JC/A Levels">JC/A Levels</SelectItem>
                     <SelectItem value="Poly">Poly</SelectItem>
                     <SelectItem value="Others">Others</SelectItem>

--- a/src/app/(admin)/tutors/components/edit-tutor/EditTutor.tsx
+++ b/src/app/(admin)/tutors/components/edit-tutor/EditTutor.tsx
@@ -42,7 +42,6 @@ import {
   collapseTextSpaces,
   normalizeTextSpaces,
   stripLeadingSpaces,
-  trimText,
 } from "@/utils/form-normalizers";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { SquarePen } from "lucide-react";
@@ -364,10 +363,14 @@ export function EditTutor({ id }: EditTutorProps) {
         educationOptions,
         "Undergraduate",
       ),
-      academicDetails: trimText(data.academicDetails || "") as string,
-      teachingSummary: trimText(data.teachingSummary || "") as string,
-      studentResults: trimText(data.studentResults || "") as string,
-      sellingPoints: trimText(data.sellingPoints || "") as string,
+      academicDetails: normalizeTextSpaces(
+        data.academicDetails || "",
+      ) as string,
+      teachingSummary: normalizeTextSpaces(
+        data.teachingSummary || "",
+      ) as string,
+      studentResults: normalizeTextSpaces(data.studentResults || "") as string,
+      sellingPoints: normalizeTextSpaces(data.sellingPoints || "") as string,
       agreeTerms:
         typeof data.agreeTerms === "boolean" ? data.agreeTerms : undefined,
       agreeAssignmentInfo:
@@ -448,28 +451,28 @@ export function EditTutor({ id }: EditTutorProps) {
   });
   const academicDetailsRegister = form.register("academicDetails", {
     onBlur: (event) => {
-      setValue("academicDetails", trimText(event.target.value) as string, {
+      setValue("academicDetails", collapseTextSpaces(event.target.value), {
         shouldValidate: true,
       });
     },
   });
   const teachingSummaryRegister = form.register("teachingSummary", {
     onBlur: (event) => {
-      setValue("teachingSummary", trimText(event.target.value) as string, {
+      setValue("teachingSummary", collapseTextSpaces(event.target.value), {
         shouldValidate: true,
       });
     },
   });
   const studentResultsRegister = form.register("studentResults", {
     onBlur: (event) => {
-      setValue("studentResults", trimText(event.target.value) as string, {
+      setValue("studentResults", collapseTextSpaces(event.target.value), {
         shouldValidate: true,
       });
     },
   });
   const sellingPointsRegister = form.register("sellingPoints", {
     onBlur: (event) => {
-      setValue("sellingPoints", trimText(event.target.value) as string, {
+      setValue("sellingPoints", collapseTextSpaces(event.target.value), {
         shouldValidate: true,
       });
     },

--- a/src/app/(admin)/tutors/components/edit-tutor/EditTutor.tsx
+++ b/src/app/(admin)/tutors/components/edit-tutor/EditTutor.tsx
@@ -42,6 +42,7 @@ import {
   collapseTextSpaces,
   normalizeTextSpaces,
   stripLeadingSpaces,
+  trimText,
 } from "@/utils/form-normalizers";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { SquarePen } from "lucide-react";
@@ -363,10 +364,10 @@ export function EditTutor({ id }: EditTutorProps) {
         educationOptions,
         "Undergraduate",
       ),
-      academicDetails: data.academicDetails || "",
-      teachingSummary: data.teachingSummary || "",
-      studentResults: data.studentResults || "",
-      sellingPoints: data.sellingPoints || "",
+      academicDetails: trimText(data.academicDetails || "") as string,
+      teachingSummary: trimText(data.teachingSummary || "") as string,
+      studentResults: trimText(data.studentResults || "") as string,
+      sellingPoints: trimText(data.sellingPoints || "") as string,
       agreeTerms:
         typeof data.agreeTerms === "boolean" ? data.agreeTerms : undefined,
       agreeAssignmentInfo:
@@ -441,6 +442,34 @@ export function EditTutor({ id }: EditTutorProps) {
     },
     onBlur: (event) => {
       setValue("fullName", collapseTextSpaces(event.target.value), {
+        shouldValidate: true,
+      });
+    },
+  });
+  const academicDetailsRegister = form.register("academicDetails", {
+    onBlur: (event) => {
+      setValue("academicDetails", trimText(event.target.value) as string, {
+        shouldValidate: true,
+      });
+    },
+  });
+  const teachingSummaryRegister = form.register("teachingSummary", {
+    onBlur: (event) => {
+      setValue("teachingSummary", trimText(event.target.value) as string, {
+        shouldValidate: true,
+      });
+    },
+  });
+  const studentResultsRegister = form.register("studentResults", {
+    onBlur: (event) => {
+      setValue("studentResults", trimText(event.target.value) as string, {
+        shouldValidate: true,
+      });
+    },
+  });
+  const sellingPointsRegister = form.register("sellingPoints", {
+    onBlur: (event) => {
+      setValue("sellingPoints", trimText(event.target.value) as string, {
         shouldValidate: true,
       });
     },
@@ -872,7 +901,7 @@ export function EditTutor({ id }: EditTutorProps) {
               <Textarea
                 id="academicDetails"
                 placeholder="Academic Details"
-                {...form.register("academicDetails")}
+                {...academicDetailsRegister}
               />
               {formState.errors.academicDetails && (
                 <p className="text-sm text-red-500">
@@ -887,7 +916,7 @@ export function EditTutor({ id }: EditTutorProps) {
               <Textarea
                 id="teachingSummary"
                 placeholder="Teaching Summary"
-                {...form.register("teachingSummary")}
+                {...teachingSummaryRegister}
               />
               {formState.errors.teachingSummary && (
                 <p className="text-sm text-red-500">
@@ -901,7 +930,7 @@ export function EditTutor({ id }: EditTutorProps) {
               <Textarea
                 id="studentResults"
                 placeholder="Student Results"
-                {...form.register("studentResults")}
+                {...studentResultsRegister}
               />
               {formState.errors.studentResults && (
                 <p className="text-sm text-red-500">
@@ -915,7 +944,7 @@ export function EditTutor({ id }: EditTutorProps) {
               <Textarea
                 id="sellingPoints"
                 placeholder="Selling Points"
-                {...form.register("sellingPoints")}
+                {...sellingPointsRegister}
               />
               {formState.errors.sellingPoints && (
                 <p className="text-sm text-red-500">

--- a/src/app/(admin)/tutors/components/edit-tutor/schema.ts
+++ b/src/app/(admin)/tutors/components/edit-tutor/schema.ts
@@ -1,9 +1,9 @@
-import { normalizeTextSpaces, trimText } from "@/utils/form-normalizers";
+import { normalizeTextSpaces } from "@/utils/form-normalizers";
 import { z } from "zod";
 
-const trimmedTextSchema = z
+const normalizedTextSchema = z
   .string()
-  .transform((value) => trimText(value) as string);
+  .transform((value) => normalizeTextSpaces(value) as string);
 
 export const updateTutorSchema = z.object({
   fullName: z
@@ -154,11 +154,11 @@ export const updateTutorSchema = z.object({
     ])
     .optional(),
 
-  academicDetails: trimmedTextSchema.pipe(z.string().max(1000)).optional(),
+  academicDetails: normalizedTextSchema.pipe(z.string().max(1000)).optional(),
 
-  teachingSummary: trimmedTextSchema.pipe(z.string().max(750)).optional(),
-  studentResults: trimmedTextSchema.pipe(z.string().max(750)).optional(),
-  sellingPoints: trimmedTextSchema.pipe(z.string().max(750)).optional(),
+  teachingSummary: normalizedTextSchema.pipe(z.string().max(750)).optional(),
+  studentResults: normalizedTextSchema.pipe(z.string().max(750)).optional(),
+  sellingPoints: normalizedTextSchema.pipe(z.string().max(750)).optional(),
 
   agreeTerms: z.boolean().optional(),
   agreeAssignmentInfo: z.boolean().optional(),

--- a/src/app/(admin)/tutors/components/edit-tutor/schema.ts
+++ b/src/app/(admin)/tutors/components/edit-tutor/schema.ts
@@ -1,7 +1,19 @@
+import { normalizeTextSpaces } from "@/utils/form-normalizers";
 import { z } from "zod";
 
 export const updateTutorSchema = z.object({
-  fullName: z.string().optional(),
+  fullName: z
+    .string()
+    .transform((value) => normalizeTextSpaces(value) as string)
+    .pipe(
+      z
+        .string()
+        .regex(
+          /^[A-Za-z\s]*$/,
+          "Full Name can contain letters and spaces only",
+        ),
+    )
+    .optional(),
   contactNumber: z
     .string()
     .min(1, "Contact Number is required")

--- a/src/app/(admin)/tutors/components/edit-tutor/schema.ts
+++ b/src/app/(admin)/tutors/components/edit-tutor/schema.ts
@@ -4,13 +4,20 @@ export const updateTutorSchema = z.object({
   fullName: z.string().optional(),
   contactNumber: z
     .string()
+    .min(1, "Contact Number is required")
     .regex(/^\d+$/, "Contact number must contain only numbers")
     .min(7, "Contact number must be at least 7 digits")
     .max(15, "Contact number must be at most 15 digits")
     .optional(),
-  email: z.string().email("Email must be valid").optional(),
+  email: z
+    .string()
+    .trim()
+    .min(1, "Email is required")
+    .email("Email must be valid")
+    .optional(),
   dateOfBirth: z
     .string()
+    .min(1, "Date of Birth is required")
     .regex(/^\d{4}-\d{2}-\d{2}$/, "Date of Birth must be in YYYY-MM-DD")
     .optional(),
   gender: z.enum(["Male", "Female"]).optional(),
@@ -24,9 +31,7 @@ export const updateTutorSchema = z.object({
     .enum(["Sinhalese", "Tamil", "Muslim", "Burgher", "Others"])
     .optional(),
 
-  status: z
-    .enum(["pending", "approved", "rejected", "suspended"])
-    .optional(),
+  status: z.enum(["pending", "approved", "rejected", "suspended"]).optional(),
 
   classType: z.array(z.string()).optional(),
 

--- a/src/app/(admin)/tutors/components/edit-tutor/schema.ts
+++ b/src/app/(admin)/tutors/components/edit-tutor/schema.ts
@@ -1,5 +1,9 @@
-import { normalizeTextSpaces } from "@/utils/form-normalizers";
+import { normalizeTextSpaces, trimText } from "@/utils/form-normalizers";
 import { z } from "zod";
+
+const trimmedTextSchema = z
+  .string()
+  .transform((value) => trimText(value) as string);
 
 export const updateTutorSchema = z.object({
   fullName: z
@@ -150,11 +154,11 @@ export const updateTutorSchema = z.object({
     ])
     .optional(),
 
-  academicDetails: z.string().max(1000).optional(),
+  academicDetails: trimmedTextSchema.pipe(z.string().max(1000)).optional(),
 
-  teachingSummary: z.string().max(750).optional(),
-  studentResults: z.string().max(750).optional(),
-  sellingPoints: z.string().max(750).optional(),
+  teachingSummary: trimmedTextSchema.pipe(z.string().max(750)).optional(),
+  studentResults: trimmedTextSchema.pipe(z.string().max(750)).optional(),
+  sellingPoints: trimmedTextSchema.pipe(z.string().max(750)).optional(),
 
   agreeTerms: z.boolean().optional(),
   agreeAssignmentInfo: z.boolean().optional(),

--- a/src/components/MultiFileUploader.tsx
+++ b/src/components/MultiFileUploader.tsx
@@ -105,18 +105,7 @@ export default function MultiFileUploadDropzone(
               fileType: file.type,
             }),
           }).then((res) => res.json());
-        try {
-          const signed = await fetch("/api/upload-url", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              fileName: `${Date.now()}-${file.name}`,
-              fileType: file.type,
-            }),
-          }).then((res) => res.json());
 
-          const uploadUrl = signed.uploadUrl;
-          if (!uploadUrl) throw new Error("Failed to generate upload URL");
           const uploadUrl = signed.uploadUrl;
           if (!uploadUrl) throw new Error("Failed to generate upload URL");
 
@@ -128,16 +117,7 @@ export default function MultiFileUploadDropzone(
             },
             body: file,
           });
-          const uploadRes = await fetch(uploadUrl, {
-            method: "PUT",
-            headers: {
-              "x-ms-blob-type": "BlockBlob",
-              "Content-Type": file.type,
-            },
-            body: file,
-          });
 
-          if (!uploadRes.ok) throw new Error("Upload failed");
           if (!uploadRes.ok) throw new Error("Upload failed");
 
           fileObj.url = uploadUrl.split("?")[0];
@@ -198,14 +178,6 @@ export default function MultiFileUploadDropzone(
     );
   };
 
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    onDrop,
-    multiple: true,
-    accept: {
-      "image/*": [],
-      "application/pdf": [],
-    },
-  });
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     multiple: true,

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -94,7 +94,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="dialog-header"
       className={cn(
-        "sticky top-0 z-20 flex flex-col gap-2 pb-3 text-center sm:text-left bg-background dark:bg-gray-800",
+        "sticky top-0 z-20 flex flex-col gap-2 pb-3 text-center sm:text-left",
         className,
       )}
       {...props}

--- a/src/utils/form-normalizers.ts
+++ b/src/utils/form-normalizers.ts
@@ -1,0 +1,15 @@
+export const normalizeTextSpaces = (value: unknown) =>
+  typeof value === "string" ? value.trim().replace(/\s+/g, " ") : value;
+
+export const trimText = (value: unknown) =>
+  typeof value === "string" ? value.trim() : value;
+
+export const removeWhitespace = <T>(value: T): T extends string ? string : T =>
+  (typeof value === "string"
+    ? value.replace(/\s+/g, "")
+    : value) as T extends string ? string : T;
+
+export const stripLeadingSpaces = (value: string) => value.replace(/^\s+/, "");
+
+export const collapseTextSpaces = (value: string) =>
+  value.replace(/^\s+/, "").replace(/\s+/g, " ").trimEnd();


### PR DESCRIPTION
**Summary**
- Fixed uploader syntax/build issue by removing duplicated upload logic in `MultiFileUploader`.
- Set certificate upload mode for Add/Edit Tutor certificate fields.
- Normalized tutor Full Name handling in Add/Edit Tutor forms.
- Normalized Academic Details, Teaching Summary, Student Results, and Selling Points fields.
- Changed Add Tutor long-text profile fields from single-line inputs to textareas.
- Fixed Request for Tutors grade display to show grade names instead of IDs.
- Fixed Tutor Request Details modal to show grade and subject names instead of IDs.
- Improved Grade column readability by widening/wrapping long grade names.

**Details**
- Added form normalizers for trimming/collapsing whitespace.
- Full Name now strips leading spaces while typing and collapses repeated spaces on blur/save.
- Tutor profile text fields now collapse repeated whitespace before display/save.
- Request for Tutors table resolves grade IDs through the grades API.
- Tutor Request Details modal resolves grade and subject IDs through existing grade/subject APIs.
- Raw grade IDs are still preserved where needed for Assign Tutor filtering.
