### PR TITLE
TM-762: Role-Based Access & Error Handling Update

### DIFF
--- a/src/components/auth/form-sign-in/SignInForm.tsx
+++ b/src/components/auth/form-sign-in/SignInForm.tsx
@@ -12,6 +12,9 @@ import { FormProvider, useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 import { initialFormValues, LoginSchema, loginSchema } from "./schema";
 
+const ACCESS_DENIED_MESSAGE =
+  "Access denied: You do not have permission to view this panel";
+
 export default function SignInForm() {
   const [isChecked, setIsChecked] = useState(false);
   const { login, isAuthError, setIsAuthError, isLoading } = useAuthContext();
@@ -32,6 +35,14 @@ export default function SignInForm() {
 
   useEffect(() => {
     if (isAuthError) {
+      if (
+        isAuthError === ACCESS_DENIED_MESSAGE ||
+        isAuthError === `${ACCESS_DENIED_MESSAGE}.`
+      ) {
+        toast.error(ACCESS_DENIED_MESSAGE);
+        return;
+      }
+
       toast.error("Invalid credentials. Email or password wrong.");
     }
   }, [isAuthError]);

--- a/src/components/auth/form-sign-in/SignInForm.tsx
+++ b/src/components/auth/form-sign-in/SignInForm.tsx
@@ -48,6 +48,7 @@ export default function SignInForm() {
   }, [isAuthError]);
 
   const onSubmit = (data: LoginSchema) => {
+    setIsAuthError(null);
     login(data);
   };
 


### PR DESCRIPTION
### Summary
- Added role check during login to allow only **admin users**
- If a non-admin (e.g., tutor) logs in, access is denied
- Error messages are now shown as **snackbar (toast)** notifications instead of inline text

### Behavior
- ✅ Admin → Login successful
- ❌ Invalid credentials → "Invalid credentials" toast
- ❌ Non-admin → "Access denied: You do not have permission to view this panel." toast

### Notes
- Unauthorized users are logged out and local data is cleared