### PR TITLE
feat: add past paper scraper and uploader scripts for O/L and A/L

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Claude Code
+.claude/

--- a/scripts/delete-papers.mjs
+++ b/scripts/delete-papers.mjs
@@ -13,19 +13,7 @@ import readline from "readline";
 const API_BASE = "https://tutorme-backend-api-d7a6cjdkgnedbxf0.southeastasia-01.azurewebsites.net";
 const PAPERS_DIR = "D:/Download/2026.04.07";
 
-const GRADE_MAP = {
-  1: "69d79165c6b6954ecfb179bf",
-  2: "69d79165c6b6954ecfb179bf",
-  3: "69d79165c6b6954ecfb179bf",
-  4: "69d79165c6b6954ecfb179bf",
-  5: "69d79186c6b6952f1ab179cf",
-  6: "69d7918fc6b69553a3b179d3",
-  7: "69d7918fc6b69553a3b179d3",
-  8: "69d7918fc6b69553a3b179d3",
-  9: "69d7918fc6b69553a3b179d3",
-  10: "69d791dec6b695cea3b179e5",
-  11: "69d791dec6b695cea3b179e5",
-};
+const SUPPORTED_GRADES = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 
 function prompt(question) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -114,7 +102,7 @@ function buildTargetTitles() {
     if (!parsed) continue;
 
     const { gradeNumber, subject, medium } = parsed;
-    if (!GRADE_MAP[gradeNumber]) continue;
+    if (!SUPPORTED_GRADES.has(gradeNumber)) continue;
 
     const folderPath = path.join(PAPERS_DIR, folder);
     const pdfs = fs.readdirSync(folderPath).filter((f) => f.toLowerCase().endsWith(".pdf"));

--- a/scripts/delete-papers.mjs
+++ b/scripts/delete-papers.mjs
@@ -1,0 +1,192 @@
+/**
+ * Delete papers we uploaded from D:/Download/2026.04.07
+ * Matches by generated titles (both old format with year and new format without year).
+ * Safe: only deletes exact title matches — pre-existing papers are untouched.
+ *
+ * Usage: node scripts/delete-papers.mjs <email> <password>
+ */
+
+import fs from "fs";
+import path from "path";
+import readline from "readline";
+
+const API_BASE = "https://tutorme-backend-api-d7a6cjdkgnedbxf0.southeastasia-01.azurewebsites.net";
+const PAPERS_DIR = "D:/Download/2026.04.07";
+
+const GRADE_MAP = {
+  1: "69d79165c6b6954ecfb179bf",
+  2: "69d79165c6b6954ecfb179bf",
+  3: "69d79165c6b6954ecfb179bf",
+  4: "69d79165c6b6954ecfb179bf",
+  5: "69d79186c6b6952f1ab179cf",
+  6: "69d7918fc6b69553a3b179d3",
+  7: "69d7918fc6b69553a3b179d3",
+  8: "69d7918fc6b69553a3b179d3",
+  9: "69d7918fc6b69553a3b179d3",
+  10: "69d791dec6b695cea3b179e5",
+  11: "69d791dec6b695cea3b179e5",
+};
+
+function prompt(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => rl.question(question, (ans) => { rl.close(); resolve(ans); }));
+}
+
+async function login(email, password, retries = 5) {
+  for (let i = 0; i < retries; i++) {
+    const res = await fetch(`${API_BASE}/v1/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    const text = await res.text();
+    if (text.startsWith("Too many")) {
+      const wait = (i + 1) * 10000;
+      console.log(`  Rate limited — waiting ${wait / 1000}s...`);
+      await new Promise((r) => setTimeout(r, wait));
+      continue;
+    }
+    const data = JSON.parse(text);
+    if (!res.ok) throw new Error(`Login failed: ${data.message}`);
+    return data.tokens.access.token;
+  }
+  throw new Error("Login failed after retries");
+}
+
+async function fetchAllPapers(token) {
+  const res = await fetch(`${API_BASE}/v1/papers?page=1&limit=10000`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await res.json();
+  return data.results ?? [];
+}
+
+async function deletePaper(token, id) {
+  const res = await fetch(`${API_BASE}/v1/papers/${id}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Delete failed (${res.status}): ${text}`);
+  }
+}
+
+// ─── Parsers (identical to upload script) ────────────────────────────────────
+
+function parseFolderName(folderName) {
+  const match = folderName.match(/^Grade\s+(\d+)\s+(.+?)\s+(sinhala|english|tamil)\s+medium$/i);
+  if (!match) return null;
+  return {
+    gradeNumber: parseInt(match[1]),
+    subject: match[2].trim(),
+    medium: match[3].charAt(0).toUpperCase() + match[3].slice(1).toLowerCase(),
+  };
+}
+
+function parseFileName(fileName) {
+  const yearMatch = fileName.match(/(\d{4})/);
+  const ordinalMatch = fileName.match(/(1st|2nd|3rd)/i);
+  const numericMatch = fileName.match(/-(\d)-term/i);
+  const ORDINAL = { "1": "1st", "2": "2nd", "3": "3rd" };
+  let term = null;
+  if (ordinalMatch) {
+    term = ordinalMatch[1].toLowerCase();
+  } else if (numericMatch) {
+    term = ORDINAL[numericMatch[1]] ?? null;
+  }
+  if (!yearMatch || !term) return null;
+  return { year: yearMatch[1], term };
+}
+
+// ─── Build the set of all titles we could have generated ─────────────────────
+
+function buildTargetTitles() {
+  const titles = new Set();
+
+  const folders = fs.readdirSync(PAPERS_DIR).filter((name) => {
+    const full = path.join(PAPERS_DIR, name);
+    return fs.statSync(full).isDirectory() && /^Grade\s+\d+/i.test(name);
+  });
+
+  for (const folder of folders) {
+    const parsed = parseFolderName(folder);
+    if (!parsed) continue;
+
+    const { gradeNumber, subject, medium } = parsed;
+    if (!GRADE_MAP[gradeNumber]) continue;
+
+    const folderPath = path.join(PAPERS_DIR, folder);
+    const pdfs = fs.readdirSync(folderPath).filter((f) => f.toLowerCase().endsWith(".pdf"));
+
+    for (const pdf of pdfs) {
+      const fileParsed = parseFileName(pdf);
+      if (!fileParsed) continue;
+
+      const { year, term } = fileParsed;
+
+      // new format (no year in title) — what we're switching to
+      titles.add(`Grade ${gradeNumber} ${subject} ${medium} Medium ${term} Term Test Paper`.toLowerCase().trim());
+
+      // old format (year in title) — what was previously uploaded
+      titles.add(`Grade ${gradeNumber} ${subject} ${medium} Medium ${term} Term Test Paper ${year}`.toLowerCase().trim());
+    }
+  }
+
+  return titles;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("=== TutorMe Paper Deleter ===\n");
+  console.log("This will ONLY delete papers whose titles match what we generated from:");
+  console.log(`  ${PAPERS_DIR}\n`);
+
+  const email    = process.argv[2] ?? await prompt("Admin email: ");
+  const password = process.argv[3] ?? await prompt("Admin password: ");
+
+  console.log("\nLogging in...");
+  const token = await login(email, password);
+  console.log("✓ Logged in\n");
+
+  console.log("Building target title set from folder structure...");
+  const targetTitles = buildTargetTitles();
+  console.log(`✓ ${targetTitles.size} distinct titles generated\n`);
+
+  console.log("Fetching all papers from DB...");
+  const papers = await fetchAllPapers(token);
+  console.log(`✓ ${papers.length} papers in DB\n`);
+
+  const toDelete = papers.filter((p) => targetTitles.has(p.title.toLowerCase().trim()));
+  console.log(`Found ${toDelete.length} papers to delete (${papers.length - toDelete.length} will be kept)\n`);
+
+  if (toDelete.length === 0) {
+    console.log("Nothing to delete.");
+    return;
+  }
+
+  let deleted = 0;
+  let errors  = 0;
+
+  for (const paper of toDelete) {
+    try {
+      process.stdout.write(`  Deleting: ${paper.title} ... `);
+      await deletePaper(token, paper.id);
+      console.log("✓");
+      deleted++;
+    } catch (err) {
+      console.log(`✗ ${err.message}`);
+      errors++;
+    }
+  }
+
+  console.log("\n=== Done ===");
+  console.log(`  ✓ Deleted : ${deleted}`);
+  console.log(`  ✗ Errors  : ${errors}`);
+}
+
+main().catch((err) => {
+  console.error("\nFatal error:", err.message);
+  process.exit(1);
+});

--- a/scripts/scrape-al-papers.mjs
+++ b/scripts/scrape-al-papers.mjs
@@ -1,0 +1,313 @@
+/**
+ * GovDoc.lk A/L Past Paper Scraper
+ * Downloads all G.C.E. Advanced Level past papers and organises them into folders.
+ *
+ * Usage:
+ *   node scripts/scrape-al-papers.mjs
+ *
+ * Output folder structure (consistent with upload-papers.mjs convention):
+ *   {OUTPUT_DIR}/AL {Subject} {medium} medium/
+ *     al-{subject-slug}-{medium}-{year}.pdf
+ */
+
+import fs from "fs";
+import path from "path";
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+const BASE_URL   = "https://govdoc.lk";
+const START_URL  = "https://govdoc.lk/category/past-papers/gce-advance-level-exam";
+const OUTPUT_DIR = "D:/Download/AL-Papers";
+const DELAY_MS   = 1500; // polite delay between requests
+
+// ─── HTTP helpers ─────────────────────────────────────────────────────────────
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HEADERS = {
+  "User-Agent":      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124",
+  "Accept":          "text/html,application/xhtml+xml,*/*;q=0.8",
+  "Accept-Language": "en-US,en;q=0.5",
+  "Referer":         BASE_URL,
+};
+
+async function fetchHtml(url, attempt = 1) {
+  try {
+    const res = await fetch(url, { headers: HEADERS });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.text();
+  } catch (err) {
+    if (attempt < 4) {
+      const wait = attempt * 3000;
+      console.log(`    Retrying in ${wait / 1000}s... (${err.message})`);
+      await sleep(wait);
+      return fetchHtml(url, attempt + 1);
+    }
+    throw err;
+  }
+}
+
+async function downloadBinary(url, destPath, attempt = 1) {
+  try {
+    const res = await fetch(url, { headers: HEADERS });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const ct = res.headers.get("content-type") ?? "";
+    if (ct.includes("text/html")) return false; // got a page, not a file
+
+    const buf = await res.arrayBuffer();
+    fs.writeFileSync(destPath, Buffer.from(buf));
+    return true;
+  } catch (err) {
+    if (attempt < 4) {
+      await sleep(attempt * 3000);
+      return downloadBinary(url, destPath, attempt + 1);
+    }
+    throw err;
+  }
+}
+
+// ─── Parsers ──────────────────────────────────────────────────────────────────
+
+// Extract paper card links from a listing page
+// Actual HTML uses unquoted hrefs: <a class=custom-card href=https://govdoc.lk/slug>
+// Titles are in: <h5 class=cate-title>Title</h5>
+function extractPaperLinks(html) {
+  // Extract hrefs from custom-card anchors (unquoted href attribute)
+  const hrefRe = /class=custom-card\s+href=(https:\/\/govdoc\.lk\/[^\s>]+)/gi;
+  const urls   = [];
+  let m;
+  while ((m = hrefRe.exec(html)) !== null) urls.push(m[1]);
+
+  // Extract titles from cate-title h5 elements
+  const titleRe = /<h5[^>]*class=cate-title[^>]*>([\s\S]*?)<\/h5>/gi;
+  const titles  = [];
+  while ((m = titleRe.exec(html)) !== null) {
+    titles.push(m[1].replace(/<[^>]+>/g, "").trim());
+  }
+
+  // Zip them together by position
+  const results = [];
+  for (let i = 0; i < Math.min(urls.length, titles.length); i++) {
+    if (urls[i] && titles[i]) results.push({ url: urls[i], title: decodeHtml(titles[i]) });
+  }
+  return [...new Map(results.map((r) => [r.url, r])).values()];
+}
+
+// Pagination uses ?page=N query param
+function buildPageUrl(pageNum) {
+  return pageNum === 1
+    ? START_URL
+    : `${START_URL}?page=${pageNum}`;
+}
+
+// Parse title → {subject, year}
+// "G.C.E. Advance Level Exam 2025 History Past Papers"
+function parsePaperTitle(title) {
+  const yearMatch    = title.match(/(\d{4})/);
+  const subjectMatch = title.match(/Exam\s+\d{4}\s+(.+?)\s+Past Papers?/i);
+  if (!yearMatch || !subjectMatch) return null;
+  return { year: yearMatch[1], subject: subjectMatch[1].trim() };
+}
+
+// Extract per-medium download entries from a detail page
+// Returns [{medium, id, label}, ...]
+function extractMediaLinks(html) {
+  const entries = [];
+  // <a href="/view?id=X&amp;fid=Y">Sinhala</a>  or  href="https://govdoc.lk/view?..."
+  const re = /<a[^>]*href="(?:https:\/\/govdoc\.lk)?\/view\?id=(\d+)&(?:amp;)?fid=([^"&\s]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const rawLabel = m[3].replace(/<[^>]+>/g, "").trim();
+    if (!rawLabel) continue;
+
+    let medium = null;
+    if (/sinhala/i.test(rawLabel))      medium = "Sinhala";
+    else if (/english/i.test(rawLabel)) medium = "English";
+    else if (/tamil/i.test(rawLabel))   medium = "Tamil";
+
+    if (!medium) continue;
+
+    entries.push({ medium, id: m[1], fid: m[2], label: rawLabel });
+  }
+  return entries;
+}
+
+// If /downloadFile/{id} returns HTML, parse the real file URL from the download page
+function extractFileUrl(html) {
+  const m = html.match(/href="([^"]+\/downloadFile\/[^"]+)"/i)
+         ?? html.match(/href="([^"]+\/download\/[^"]+)"/i);
+  return m ? m[1] : null;
+}
+
+function decodeHtml(str) {
+  return str
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'");
+}
+
+function slugify(str) {
+  return str.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+// Build PDF filename — consistent with upload-papers.mjs parseFileName expectations
+// e.g. al-history-sinhala-2025.pdf
+function buildFileName(subject, medium, year) {
+  return `al-${slugify(subject)}-${medium.toLowerCase()}-${year}.pdf`;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("=== GovDoc A/L Paper Scraper ===");
+  console.log(`Output : ${OUTPUT_DIR}\n`);
+
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  // ── Step 1: walk all listing pages and collect detail page URLs ────────────
+  const paperMap = new Map(); // detailUrl → title
+  let pageNum    = 1;
+
+  while (true) {
+    const listUrl = buildPageUrl(pageNum);
+    console.log(`Fetching listing page ${pageNum}: ${listUrl}`);
+
+    let html;
+    try {
+      html = await fetchHtml(listUrl);
+    } catch (err) {
+      console.log(`  ERROR: ${err.message}`);
+      break;
+    }
+
+    const links = extractPaperLinks(html);
+    console.log(`  Found ${links.length} papers`);
+
+    // Stop when page returns no cards (past the last page)
+    if (links.length === 0) break;
+
+    const prevSize = paperMap.size;
+    for (const { url, title } of links) paperMap.set(url, title);
+
+    // Stop if this page added no new unique papers (duplicate page)
+    if (paperMap.size === prevSize) {
+      console.log(`  No new papers — reached last page`);
+      break;
+    }
+
+    pageNum++;
+    await sleep(DELAY_MS);
+  }
+
+  console.log(`\nTotal papers to process: ${paperMap.size}\n`);
+
+  if (paperMap.size === 0) {
+    console.log("No papers found — check the START_URL or site structure.");
+    return;
+  }
+
+  let downloaded = 0;
+  let skipped    = 0;
+  let errors     = 0;
+
+  // ── Step 2: process each detail page ──────────────────────────────────────
+  for (const [detailUrl, rawTitle] of paperMap) {
+    const parsed = parsePaperTitle(rawTitle);
+    if (!parsed) {
+      console.log(`SKIP (unparseable title): ${rawTitle}`);
+      skipped++;
+      continue;
+    }
+
+    const { subject, year } = parsed;
+    console.log(`\n[${year}] ${subject}`);
+
+    let html;
+    try {
+      html = await fetchHtml(detailUrl);
+      await sleep(DELAY_MS);
+    } catch (err) {
+      console.log(`  ERROR fetching detail page: ${err.message}`);
+      errors++;
+      continue;
+    }
+
+    const mediaLinks = extractMediaLinks(html);
+    if (mediaLinks.length === 0) {
+      console.log(`  SKIP: no Sinhala/English/Tamil links found`);
+      skipped++;
+      continue;
+    }
+
+    console.log(`  Mediums: ${[...new Set(mediaLinks.map((l) => l.medium))].join(", ")}`);
+
+    // ── Step 3: download each PDF ────────────────────────────────────────────
+    const downloadedThisEntry = new Set();
+
+    for (const { medium, id } of mediaLinks) {
+      // Folder name consistent with Grade X Subject medium medium convention
+      const folderName = `AL ${subject} ${medium.toLowerCase()} medium`;
+      const folderPath = path.join(OUTPUT_DIR, folderName);
+      fs.mkdirSync(folderPath, { recursive: true });
+
+      const fileName = buildFileName(subject, medium, year);
+
+      // Skip duplicates within the same paper entry (e.g. two links for same medium)
+      if (downloadedThisEntry.has(fileName)) {
+        skipped++;
+        continue;
+      }
+
+      const filePath = path.join(folderPath, fileName);
+
+      if (fs.existsSync(filePath)) {
+        console.log(`  SKIP (exists): ${fileName}`);
+        skipped++;
+        continue;
+      }
+
+      process.stdout.write(`  Downloading [${medium}] ${fileName} ... `);
+
+      try {
+        // Try direct download first: /downloadFile/{id}
+        const directUrl = `${BASE_URL}/downloadFile/${id}`;
+        let ok = await downloadBinary(directUrl, filePath);
+
+        if (!ok) {
+          // Fallback: load the download landing page and parse the real URL
+          const dlPage = await fetchHtml(`${BASE_URL}/download/${id}`);
+          await sleep(DELAY_MS);
+          const fileUrl = extractFileUrl(dlPage);
+          if (!fileUrl) throw new Error("cannot find file URL on download page");
+          const fullUrl = fileUrl.startsWith("http") ? fileUrl : `${BASE_URL}${fileUrl}`;
+          ok = await downloadBinary(fullUrl, filePath);
+          if (!ok) throw new Error("download page also returned HTML");
+        }
+
+        console.log("✓");
+        downloadedThisEntry.add(fileName);
+        downloaded++;
+      } catch (err) {
+        console.log(`✗ ${err.message}`);
+        if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+        errors++;
+      }
+
+      await sleep(DELAY_MS);
+    }
+  }
+
+  console.log("\n=== Done ===");
+  console.log(`  ✓ Downloaded : ${downloaded}`);
+  console.log(`  ⚠ Skipped   : ${skipped}`);
+  console.log(`  ✗ Errors    : ${errors}`);
+  console.log(`\nFolders saved to: ${OUTPUT_DIR}`);
+}
+
+main().catch((err) => {
+  console.error("\nFatal error:", err.message);
+  process.exit(1);
+});

--- a/scripts/scrape-ol-papers.mjs
+++ b/scripts/scrape-ol-papers.mjs
@@ -1,0 +1,278 @@
+/**
+ * GovDoc.lk O/L Past Paper Scraper
+ * Downloads all G.C.E. Ordinary Level past papers and organises them into folders.
+ *
+ * Usage:
+ *   node scripts/scrape-ol-papers.mjs
+ *
+ * Output folder structure:
+ *   {OUTPUT_DIR}/OL {Subject} {medium} medium/
+ *     ol-{subject-slug}-{medium}-{year}.pdf
+ */
+
+import fs from "fs";
+import path from "path";
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+const BASE_URL   = "https://govdoc.lk";
+const START_URL  = "https://govdoc.lk/category/past-papers/gce-ordinary-level-exam";
+const OUTPUT_DIR = "D:/Download/OL-Papers";
+const DELAY_MS   = 1500;
+
+// ─── HTTP helpers ─────────────────────────────────────────────────────────────
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const HEADERS = {
+  "User-Agent":      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124",
+  "Accept":          "text/html,application/xhtml+xml,*/*;q=0.8",
+  "Accept-Language": "en-US,en;q=0.5",
+  "Referer":         BASE_URL,
+};
+
+async function fetchHtml(url, attempt = 1) {
+  try {
+    const res = await fetch(url, { headers: HEADERS });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.text();
+  } catch (err) {
+    if (attempt < 4) {
+      const wait = attempt * 3000;
+      console.log(`    Retrying in ${wait / 1000}s... (${err.message})`);
+      await sleep(wait);
+      return fetchHtml(url, attempt + 1);
+    }
+    throw err;
+  }
+}
+
+async function downloadBinary(url, destPath, attempt = 1) {
+  try {
+    const res = await fetch(url, { headers: HEADERS });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const ct = res.headers.get("content-type") ?? "";
+    if (ct.includes("text/html")) return false;
+
+    const buf = await res.arrayBuffer();
+    fs.writeFileSync(destPath, Buffer.from(buf));
+    return true;
+  } catch (err) {
+    if (attempt < 4) {
+      await sleep(attempt * 3000);
+      return downloadBinary(url, destPath, attempt + 1);
+    }
+    throw err;
+  }
+}
+
+// ─── Parsers ──────────────────────────────────────────────────────────────────
+
+function extractPaperLinks(html) {
+  const hrefRe  = /class=custom-card\s+href=(https:\/\/govdoc\.lk\/[^\s>]+)/gi;
+  const titleRe = /<h5[^>]*class=cate-title[^>]*>([\s\S]*?)<\/h5>/gi;
+  const urls = [], titles = [];
+  let m;
+  while ((m = hrefRe.exec(html))  !== null) urls.push(m[1]);
+  while ((m = titleRe.exec(html)) !== null) titles.push(m[1].replace(/<[^>]+>/g, "").trim());
+
+  const results = [];
+  for (let i = 0; i < Math.min(urls.length, titles.length); i++) {
+    if (urls[i] && titles[i]) results.push({ url: urls[i], title: decodeHtml(titles[i]) });
+  }
+  return [...new Map(results.map((r) => [r.url, r])).values()];
+}
+
+function buildPageUrl(pageNum) {
+  return pageNum === 1 ? START_URL : `${START_URL}?page=${pageNum}`;
+}
+
+// "G.C.E. Ordinary Level Exam 2024 Mathematics Past Papers"
+function parsePaperTitle(title) {
+  const yearMatch    = title.match(/(\d{4})/);
+  const subjectMatch = title.match(/Exam\s+\d{4}\s+(.+?)\s+Past Papers?/i);
+  if (!yearMatch || !subjectMatch) return null;
+  return { year: yearMatch[1], subject: subjectMatch[1].trim() };
+}
+
+function extractMediaLinks(html) {
+  const entries = [];
+  const re = /<a[^>]*href="(?:https:\/\/govdoc\.lk)?\/view\?id=(\d+)&(?:amp;)?fid=([^"&\s]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const rawLabel = m[3].replace(/<[^>]+>/g, "").trim();
+    if (!rawLabel) continue;
+
+    let medium = null;
+    if (/sinhala/i.test(rawLabel))      medium = "Sinhala";
+    else if (/english/i.test(rawLabel)) medium = "English";
+    else if (/tamil/i.test(rawLabel))   medium = "Tamil";
+
+    if (!medium) continue;
+    entries.push({ medium, id: m[1], fid: m[2], label: rawLabel });
+  }
+  return entries;
+}
+
+function extractFileUrl(html) {
+  const m = html.match(/href="([^"]+\/downloadFile\/[^"]+)"/i)
+         ?? html.match(/href="([^"]+\/download\/[^"]+)"/i);
+  return m ? m[1] : null;
+}
+
+function decodeHtml(str) {
+  return str
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'");
+}
+
+function slugify(str) {
+  return str.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function buildFileName(subject, medium, year) {
+  return `ol-${slugify(subject)}-${medium.toLowerCase()}-${year}.pdf`;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("=== GovDoc O/L Paper Scraper ===");
+  console.log(`Output : ${OUTPUT_DIR}\n`);
+
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  const paperMap = new Map();
+  let pageNum = 1;
+
+  while (true) {
+    const listUrl = buildPageUrl(pageNum);
+    console.log(`Fetching listing page ${pageNum}: ${listUrl}`);
+
+    let html;
+    try {
+      html = await fetchHtml(listUrl);
+    } catch (err) {
+      console.log(`  ERROR: ${err.message}`);
+      break;
+    }
+
+    const links = extractPaperLinks(html);
+    console.log(`  Found ${links.length} papers`);
+
+    if (links.length === 0) break;
+
+    const prevSize = paperMap.size;
+    for (const { url, title } of links) paperMap.set(url, title);
+
+    if (paperMap.size === prevSize) {
+      console.log(`  No new papers — reached last page`);
+      break;
+    }
+
+    pageNum++;
+    await sleep(DELAY_MS);
+  }
+
+  console.log(`\nTotal papers to process: ${paperMap.size}\n`);
+
+  if (paperMap.size === 0) {
+    console.log("No papers found — check the START_URL or site structure.");
+    return;
+  }
+
+  let downloaded = 0, skipped = 0, errors = 0;
+
+  for (const [detailUrl, rawTitle] of paperMap) {
+    const parsed = parsePaperTitle(rawTitle);
+    if (!parsed) {
+      console.log(`SKIP (unparseable title): ${rawTitle}`);
+      skipped++;
+      continue;
+    }
+
+    const { subject, year } = parsed;
+    console.log(`\n[${year}] ${subject}`);
+
+    let html;
+    try {
+      html = await fetchHtml(detailUrl);
+      await sleep(DELAY_MS);
+    } catch (err) {
+      console.log(`  ERROR fetching detail page: ${err.message}`);
+      errors++;
+      continue;
+    }
+
+    const mediaLinks = extractMediaLinks(html);
+    if (mediaLinks.length === 0) {
+      console.log(`  SKIP: no Sinhala/English/Tamil links found`);
+      skipped++;
+      continue;
+    }
+
+    console.log(`  Mediums: ${[...new Set(mediaLinks.map((l) => l.medium))].join(", ")}`);
+
+    const downloadedThisEntry = new Set();
+
+    for (const { medium, id } of mediaLinks) {
+      const folderName = `OL ${subject} ${medium.toLowerCase()} medium`;
+      const folderPath = path.join(OUTPUT_DIR, folderName);
+      fs.mkdirSync(folderPath, { recursive: true });
+
+      const fileName = buildFileName(subject, medium, year);
+
+      if (downloadedThisEntry.has(fileName)) { skipped++; continue; }
+
+      const filePath = path.join(folderPath, fileName);
+
+      if (fs.existsSync(filePath)) {
+        console.log(`  SKIP (exists): ${fileName}`);
+        skipped++;
+        continue;
+      }
+
+      process.stdout.write(`  Downloading [${medium}] ${fileName} ... `);
+
+      try {
+        const directUrl = `${BASE_URL}/downloadFile/${id}`;
+        let ok = await downloadBinary(directUrl, filePath);
+
+        if (!ok) {
+          const dlPage = await fetchHtml(`${BASE_URL}/download/${id}`);
+          await sleep(DELAY_MS);
+          const fileUrl = extractFileUrl(dlPage);
+          if (!fileUrl) throw new Error("cannot find file URL on download page");
+          const fullUrl = fileUrl.startsWith("http") ? fileUrl : `${BASE_URL}${fileUrl}`;
+          ok = await downloadBinary(fullUrl, filePath);
+          if (!ok) throw new Error("download page also returned HTML");
+        }
+
+        console.log("✓");
+        downloadedThisEntry.add(fileName);
+        downloaded++;
+      } catch (err) {
+        console.log(`✗ ${err.message}`);
+        if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+        errors++;
+      }
+
+      await sleep(DELAY_MS);
+    }
+  }
+
+  console.log("\n=== Done ===");
+  console.log(`  ✓ Downloaded : ${downloaded}`);
+  console.log(`  ⚠ Skipped   : ${skipped}`);
+  console.log(`  ✗ Errors    : ${errors}`);
+  console.log(`\nFolders saved to: ${OUTPUT_DIR}`);
+}
+
+main().catch((err) => {
+  console.error("\nFatal error:", err.message);
+  process.exit(1);
+});

--- a/scripts/upload-al-papers.mjs
+++ b/scripts/upload-al-papers.mjs
@@ -26,15 +26,6 @@ const AZURE_ACCOUNT   = "tutormeuploads";
 const AZURE_CONTAINER = "uploads";
 const AZURE_KEY       = process.env.AZURE_STORAGE_KEY ?? "";
 
-// All 5 A/L stream grade IDs — script searches all of them for each subject
-const AL_GRADE_IDS = [
-  "69d791efc6b695098cb179ed", // Physical Science Stream
-  "69d89ac2c6b69532eeb1822f", // Biological Science Stream
-  "69d89bc4c6b695a234b18239", // Commerce Stream
-  "69d89cd8c6b6953cc7b1826b", // Art Stream
-  "69d89d88c6b6955072b18280", // Technology Stream
-];
-
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function prompt(question) {
@@ -145,8 +136,7 @@ function normalizeSubject(name) {
 }
 
 // Search all A/L grades to find which stream has this subject
-function findSubjectInAlGrades(grades, subjectName) {
-  const alGrades = grades.filter((g) => AL_GRADE_IDS.includes(g.id));
+function findSubjectInAlGrades(alGrades, subjectName) {
   const normalized = normalizeSubject(subjectName);
 
   for (const grade of alGrades) {
@@ -198,7 +188,8 @@ async function main() {
 
   console.log("Fetching grades from API...");
   const grades = await fetchGrades(token);
-  const alGrades = grades.filter((g) => AL_GRADE_IDS.includes(g.id));
+  const alGrades = grades.filter((g) => /advanced level/i.test(g.title));
+  if (alGrades.length === 0) throw new Error("No A/L stream grades found in API — no grade with 'Advanced Level' in title");
   console.log(`✓ Found ${alGrades.length} A/L stream grades\n`);
 
   const folders = fs.readdirSync(PAPERS_DIR).filter((name) => {
@@ -225,7 +216,7 @@ async function main() {
     }
 
     const { subject, medium } = parsed;
-    const found = findSubjectInAlGrades(grades, subject);
+    const found = findSubjectInAlGrades(alGrades, subject);
 
     if (!found) {
       const alGradeSubjects = alGrades

--- a/scripts/upload-al-papers.mjs
+++ b/scripts/upload-al-papers.mjs
@@ -1,0 +1,295 @@
+/**
+ * A/L Past Paper Uploader
+ * Reads AL folders created by scrape-al-papers.mjs, uploads each PDF to Azure,
+ * then creates a paper record via the backend API.
+ *
+ * Folder convention (same as upload-papers.mjs):
+ *   {PAPERS_DIR}/AL {Subject} {medium} medium/
+ *     al-{subject-slug}-{medium}-{year}.pdf
+ *
+ * Title convention:
+ *   G.C.E. Advanced Level {Subject} {medium} Medium Past Paper {year}
+ *
+ * Usage: node scripts/upload-al-papers.mjs <email> <password>
+ */
+
+import fs from "fs";
+import path from "path";
+import readline from "readline";
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+const API_BASE   = "https://tutorme-backend-api-d7a6cjdkgnedbxf0.southeastasia-01.azurewebsites.net";
+const PAPERS_DIR = "D:/Download/AL-Papers";
+
+const AZURE_ACCOUNT   = "tutormeuploads";
+const AZURE_CONTAINER = "uploads";
+const AZURE_KEY       = process.env.AZURE_STORAGE_KEY ?? "";
+
+// All 5 A/L stream grade IDs — script searches all of them for each subject
+const AL_GRADE_IDS = [
+  "69d791efc6b695098cb179ed", // Physical Science Stream
+  "69d89ac2c6b69532eeb1822f", // Biological Science Stream
+  "69d89bc4c6b695a234b18239", // Commerce Stream
+  "69d89cd8c6b6953cc7b1826b", // Art Stream
+  "69d89d88c6b6955072b18280", // Technology Stream
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function prompt(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => rl.question(question, (ans) => { rl.close(); resolve(ans); }));
+}
+
+async function login(email, password, retries = 5) {
+  for (let i = 0; i < retries; i++) {
+    const res = await fetch(`${API_BASE}/v1/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    const text = await res.text();
+    if (text.startsWith("Too many")) {
+      const wait = (i + 1) * 10000;
+      console.log(`  Rate limited — waiting ${wait / 1000}s...`);
+      await new Promise((r) => setTimeout(r, wait));
+      continue;
+    }
+    const data = JSON.parse(text);
+    if (!res.ok) throw new Error(`Login failed: ${data.message}`);
+    return data.tokens.access.token;
+  }
+  throw new Error("Login failed after retries");
+}
+
+async function fetchGrades(token) {
+  const res = await fetch(`${API_BASE}/v1/grades?page=1&limit=50`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await res.json();
+  return data.results ?? [];
+}
+
+async function fetchExistingKeys(token) {
+  const res = await fetch(`${API_BASE}/v1/papers?page=1&limit=10000`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await res.json();
+  return new Set(
+    (data.results ?? []).map((p) => {
+      const medium = p.medium?.id ?? p.medium ?? "";
+      return `${p.title.toLowerCase().trim()}|${medium.toLowerCase()}|${p.year ?? ""}`;
+    }),
+  );
+}
+
+async function createPaper(token, paper) {
+  const res = await fetch(`${API_BASE}/v1/papers`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify(paper),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(`Create paper failed: ${JSON.stringify(data)}`);
+  return data;
+}
+
+// ─── Azure SAS upload (identical to upload-papers.mjs) ───────────────────────
+
+async function generateSasUrl(blobName, fileType) {
+  const { createHmac } = await import("crypto");
+  const now     = new Date();
+  const expires = new Date(now.getTime() + 60 * 60 * 1000);
+  const toIso   = (d) => d.toISOString().replace(/\.\d+Z$/, "Z");
+  const start   = toIso(now);
+  const end     = toIso(expires);
+  const permissions = "cw";
+  const signedFields = [
+    permissions, start, end,
+    `/blob/${AZURE_ACCOUNT}/${AZURE_CONTAINER}/${blobName}`,
+    "", "", "https", "2024-11-04", "b", "", "", "", "", "", "", fileType,
+  ];
+  const sig = createHmac("sha256", Buffer.from(AZURE_KEY, "base64"))
+    .update(signedFields.join("\n"), "utf8")
+    .digest("base64");
+  const params = new URLSearchParams({ sp: permissions, st: start, se: end, spr: "https", sv: "2024-11-04", sr: "b", rsct: fileType, sig });
+  return `https://${AZURE_ACCOUNT}.blob.core.windows.net/${AZURE_CONTAINER}/${blobName}?${params}`;
+}
+
+async function uploadToAzure(filePath, fileName) {
+  const fileType  = "application/pdf";
+  const blobName  = `${Date.now()}-${fileName}`;
+  const sasUrl    = await generateSasUrl(blobName, fileType);
+  const fileBuffer = fs.readFileSync(filePath);
+  const res = await fetch(sasUrl, {
+    method: "PUT",
+    headers: { "x-ms-blob-type": "BlockBlob", "Content-Type": fileType },
+    body: fileBuffer,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Azure upload failed (${res.status}): ${text}`);
+  }
+  return sasUrl.split("?")[0];
+}
+
+// ─── Subject matching ─────────────────────────────────────────────────────────
+
+function normalizeSubject(name) {
+  return name
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/\s*&\s*/g, " and ")
+    .trim();
+}
+
+// Search all A/L grades to find which stream has this subject
+function findSubjectInAlGrades(grades, subjectName) {
+  const alGrades = grades.filter((g) => AL_GRADE_IDS.includes(g.id));
+  const normalized = normalizeSubject(subjectName);
+
+  for (const grade of alGrades) {
+    if (!grade.subjects) continue;
+    const match = grade.subjects.find((s) => {
+      const db = normalizeSubject(s.title);
+      return db === normalized || db.includes(normalized) || normalized.includes(db);
+    });
+    if (match) return { gradeId: grade.id, subjectId: match.id, gradeName: grade.title };
+  }
+  return null;
+}
+
+// ─── Parsers ──────────────────────────────────────────────────────────────────
+
+// "AL History sinhala medium" → {subject: "History", medium: "Sinhala"}
+function parseFolderName(folderName) {
+  const match = folderName.match(/^AL\s+(.+?)\s+(sinhala|english|tamil)\s+medium$/i);
+  if (!match) return null;
+  return {
+    subject: match[1].trim(),
+    medium:  match[2].charAt(0).toUpperCase() + match[2].slice(1).toLowerCase(),
+  };
+}
+
+// "al-history-sinhala-2025.pdf" → {year: "2025"}
+function parseFileName(fileName) {
+  const yearMatch = fileName.match(/(\d{4})\.pdf$/i);
+  if (!yearMatch) return null;
+  return { year: yearMatch[1] };
+}
+
+// "G.C.E. Advanced Level History Sinhala Medium Past Paper 2025"
+function buildTitle(subject, medium, year) {
+  return `G.C.E. Advanced Level ${subject} ${medium} Medium Past Paper ${year}`;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("=== TutorMe A/L Paper Uploader ===\n");
+
+  const email    = process.argv[2] ?? await prompt("Admin email: ");
+  const password = process.argv[3] ?? await prompt("Admin password: ");
+
+  console.log("\nLogging in...");
+  const token = await login(email, password);
+  console.log("✓ Logged in\n");
+
+  console.log("Fetching grades from API...");
+  const grades = await fetchGrades(token);
+  const alGrades = grades.filter((g) => AL_GRADE_IDS.includes(g.id));
+  console.log(`✓ Found ${alGrades.length} A/L stream grades\n`);
+
+  const folders = fs.readdirSync(PAPERS_DIR).filter((name) => {
+    const full = path.join(PAPERS_DIR, name);
+    return fs.statSync(full).isDirectory() && /^AL\s+/i.test(name);
+  });
+  console.log(`Found ${folders.length} AL folders\n`);
+
+  console.log("Fetching existing papers to skip duplicates...");
+  const existingKeys = await fetchExistingKeys(token);
+  console.log(`✓ ${existingKeys.size} papers already in DB\n`);
+
+  const uploadedThisRun = new Set();
+  let successCount = 0;
+  let skipCount    = 0;
+  let errorCount   = 0;
+
+  for (const folder of folders) {
+    const parsed = parseFolderName(folder);
+    if (!parsed) {
+      console.log(`  SKIP (can't parse folder): ${folder}`);
+      skipCount++;
+      continue;
+    }
+
+    const { subject, medium } = parsed;
+    const found = findSubjectInAlGrades(grades, subject);
+
+    if (!found) {
+      const alGradeSubjects = alGrades
+        .flatMap((g) => (g.subjects ?? []).map((s) => s.title))
+        .join(", ");
+      console.log(`  SKIP (subject "${subject}" not found in any A/L stream). Available: ${alGradeSubjects}`);
+      skipCount++;
+      continue;
+    }
+
+    const { gradeId, subjectId, gradeName } = found;
+    const folderPath = path.join(PAPERS_DIR, folder);
+    const pdfs = fs.readdirSync(folderPath).filter((f) => f.toLowerCase().endsWith(".pdf"));
+
+    for (const pdf of pdfs) {
+      const fileParsed = parseFileName(pdf);
+      if (!fileParsed) {
+        console.log(`  SKIP (can't parse filename): ${pdf}`);
+        skipCount++;
+        continue;
+      }
+
+      const { year } = fileParsed;
+      const title    = buildTitle(subject, medium, year);
+      const dedupKey = `${title.toLowerCase().trim()}|${medium.toLowerCase()}|${year}`;
+
+      if (existingKeys.has(dedupKey) || uploadedThisRun.has(dedupKey)) {
+        console.log(`  SKIP (already exists): ${title}`);
+        skipCount++;
+        continue;
+      }
+
+      try {
+        process.stdout.write(`  Uploading [${gradeName}]: ${title} ... `);
+
+        const pdfPath   = path.join(folderPath, pdf);
+        const publicUrl = await uploadToAzure(pdfPath, pdf);
+
+        await createPaper(token, {
+          title,
+          medium,
+          subject: subjectId,
+          grade:   gradeId,
+          year,
+          url:     publicUrl,
+        });
+
+        console.log("✓");
+        uploadedThisRun.add(dedupKey);
+        successCount++;
+      } catch (err) {
+        console.log(`✗ ERROR: ${err.message}`);
+        errorCount++;
+      }
+    }
+  }
+
+  console.log("\n=== Done ===");
+  console.log(`  ✓ Uploaded : ${successCount}`);
+  console.log(`  ⚠ Skipped  : ${skipCount}`);
+  console.log(`  ✗ Errors   : ${errorCount}`);
+}
+
+main().catch((err) => {
+  console.error("\nFatal error:", err.message);
+  process.exit(1);
+});

--- a/scripts/upload-ol-papers.mjs
+++ b/scripts/upload-ol-papers.mjs
@@ -1,0 +1,279 @@
+/**
+ * O/L Past Paper Uploader
+ * Reads OL folders created by scrape-ol-papers.mjs, uploads each PDF to Azure,
+ * then creates a paper record via the backend API.
+ *
+ * Folder convention:
+ *   {PAPERS_DIR}/OL {Subject} {medium} medium/
+ *     ol-{subject-slug}-{medium}-{year}.pdf
+ *
+ * Title convention:
+ *   G.C.E. Ordinary Level {Subject} {medium} Medium Past Paper {year}
+ *
+ * Usage: node scripts/upload-ol-papers.mjs <email> <password>
+ */
+
+import fs from "fs";
+import path from "path";
+import readline from "readline";
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+const API_BASE   = "https://tutorme-backend-api-d7a6cjdkgnedbxf0.southeastasia-01.azurewebsites.net";
+const PAPERS_DIR = "D:/Download/OL-Papers";
+
+const AZURE_ACCOUNT   = "tutormeuploads";
+const AZURE_CONTAINER = "uploads";
+const AZURE_KEY       = process.env.AZURE_STORAGE_KEY ?? "";
+
+const OL_GRADE_ID = "69d791dec6b695cea3b179e5"; // G.C.E. Ordinary Level (Grade 10-11)
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function prompt(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => rl.question(question, (ans) => { rl.close(); resolve(ans); }));
+}
+
+async function login(email, password, retries = 5) {
+  for (let i = 0; i < retries; i++) {
+    const res = await fetch(`${API_BASE}/v1/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    const text = await res.text();
+    if (text.startsWith("Too many")) {
+      const wait = (i + 1) * 10000;
+      console.log(`  Rate limited — waiting ${wait / 1000}s...`);
+      await new Promise((r) => setTimeout(r, wait));
+      continue;
+    }
+    const data = JSON.parse(text);
+    if (!res.ok) throw new Error(`Login failed: ${data.message}`);
+    return data.tokens.access.token;
+  }
+  throw new Error("Login failed after retries");
+}
+
+async function fetchGrades(token) {
+  const res = await fetch(`${API_BASE}/v1/grades?page=1&limit=50`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await res.json();
+  return data.results ?? [];
+}
+
+async function fetchExistingKeys(token) {
+  const res = await fetch(`${API_BASE}/v1/papers?page=1&limit=10000`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await res.json();
+  return new Set(
+    (data.results ?? []).map((p) => {
+      const medium = p.medium?.id ?? p.medium ?? "";
+      return `${p.title.toLowerCase().trim()}|${medium.toLowerCase()}|${p.year ?? ""}`;
+    }),
+  );
+}
+
+async function createPaper(token, paper) {
+  const res = await fetch(`${API_BASE}/v1/papers`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify(paper),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(`Create paper failed: ${JSON.stringify(data)}`);
+  return data;
+}
+
+// ─── Azure SAS upload ─────────────────────────────────────────────────────────
+
+async function generateSasUrl(blobName, fileType) {
+  const { createHmac } = await import("crypto");
+  const now     = new Date();
+  const expires = new Date(now.getTime() + 60 * 60 * 1000);
+  const toIso   = (d) => d.toISOString().replace(/\.\d+Z$/, "Z");
+  const start   = toIso(now);
+  const end     = toIso(expires);
+  const permissions = "cw";
+  const signedFields = [
+    permissions, start, end,
+    `/blob/${AZURE_ACCOUNT}/${AZURE_CONTAINER}/${blobName}`,
+    "", "", "https", "2024-11-04", "b", "", "", "", "", "", "", fileType,
+  ];
+  const sig = createHmac("sha256", Buffer.from(AZURE_KEY, "base64"))
+    .update(signedFields.join("\n"), "utf8")
+    .digest("base64");
+  const params = new URLSearchParams({ sp: permissions, st: start, se: end, spr: "https", sv: "2024-11-04", sr: "b", rsct: fileType, sig });
+  return `https://${AZURE_ACCOUNT}.blob.core.windows.net/${AZURE_CONTAINER}/${blobName}?${params}`;
+}
+
+async function uploadToAzure(filePath, fileName) {
+  const fileType   = "application/pdf";
+  const blobName   = `${Date.now()}-${fileName}`;
+  const sasUrl     = await generateSasUrl(blobName, fileType);
+  const fileBuffer = fs.readFileSync(filePath);
+  const res = await fetch(sasUrl, {
+    method: "PUT",
+    headers: { "x-ms-blob-type": "BlockBlob", "Content-Type": fileType },
+    body: fileBuffer,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Azure upload failed (${res.status}): ${text}`);
+  }
+  return sasUrl.split("?")[0];
+}
+
+// ─── Subject matching ─────────────────────────────────────────────────────────
+
+function normalizeSubject(name) {
+  return name
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/\s*&\s*/g, " and ")
+    .trim();
+}
+
+function findSubjectId(grades, subjectName) {
+  const grade = grades.find((g) => g.id === OL_GRADE_ID);
+  if (!grade?.subjects) return null;
+  const normalized = normalizeSubject(subjectName);
+  const match = grade.subjects.find((s) => {
+    const db = normalizeSubject(s.title);
+    return db === normalized || db.includes(normalized) || normalized.includes(db);
+  });
+  return match?.id ?? null;
+}
+
+// ─── Parsers ──────────────────────────────────────────────────────────────────
+
+// "OL Mathematics sinhala medium" → {subject: "Mathematics", medium: "Sinhala"}
+function parseFolderName(folderName) {
+  const match = folderName.match(/^OL\s+(.+?)\s+(sinhala|english|tamil)\s+medium$/i);
+  if (!match) return null;
+  return {
+    subject: match[1].trim(),
+    medium:  match[2].charAt(0).toUpperCase() + match[2].slice(1).toLowerCase(),
+  };
+}
+
+// "ol-mathematics-sinhala-2024.pdf" → {year: "2024"}
+function parseFileName(fileName) {
+  const yearMatch = fileName.match(/(\d{4})\.pdf$/i);
+  if (!yearMatch) return null;
+  return { year: yearMatch[1] };
+}
+
+// "G.C.E. Ordinary Level Mathematics Sinhala Medium Past Paper 2024"
+function buildTitle(subject, medium, year) {
+  return `G.C.E. Ordinary Level ${subject} ${medium} Medium Past Paper ${year}`;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("=== TutorMe O/L Paper Uploader ===\n");
+
+  const email    = process.argv[2] ?? await prompt("Admin email: ");
+  const password = process.argv[3] ?? await prompt("Admin password: ");
+
+  console.log("\nLogging in...");
+  const token = await login(email, password);
+  console.log("✓ Logged in\n");
+
+  console.log("Fetching grades from API...");
+  const grades = await fetchGrades(token);
+  const olGrade = grades.find((g) => g.id === OL_GRADE_ID);
+  if (!olGrade) throw new Error("O/L grade not found in API");
+  console.log(`✓ Found O/L grade: ${olGrade.title} (${(olGrade.subjects ?? []).length} subjects)\n`);
+
+  const folders = fs.readdirSync(PAPERS_DIR).filter((name) => {
+    const full = path.join(PAPERS_DIR, name);
+    return fs.statSync(full).isDirectory() && /^OL\s+/i.test(name);
+  });
+  console.log(`Found ${folders.length} OL folders\n`);
+
+  console.log("Fetching existing papers to skip duplicates...");
+  const existingKeys = await fetchExistingKeys(token);
+  console.log(`✓ ${existingKeys.size} papers already in DB\n`);
+
+  const uploadedThisRun = new Set();
+  let successCount = 0, skipCount = 0, errorCount = 0;
+
+  for (const folder of folders) {
+    const parsed = parseFolderName(folder);
+    if (!parsed) {
+      console.log(`  SKIP (can't parse folder): ${folder}`);
+      skipCount++;
+      continue;
+    }
+
+    const { subject, medium } = parsed;
+    const subjectId = findSubjectId(grades, subject);
+
+    if (!subjectId) {
+      const available = (olGrade.subjects ?? []).map((s) => s.title).join(", ") || "none";
+      console.log(`  SKIP (subject "${subject}" not found in O/L grade). Available: ${available}`);
+      skipCount++;
+      continue;
+    }
+
+    const folderPath = path.join(PAPERS_DIR, folder);
+    const pdfs = fs.readdirSync(folderPath).filter((f) => f.toLowerCase().endsWith(".pdf"));
+
+    for (const pdf of pdfs) {
+      const fileParsed = parseFileName(pdf);
+      if (!fileParsed) {
+        console.log(`  SKIP (can't parse filename): ${pdf}`);
+        skipCount++;
+        continue;
+      }
+
+      const { year } = fileParsed;
+      const title    = buildTitle(subject, medium, year);
+      const dedupKey = `${title.toLowerCase().trim()}|${medium.toLowerCase()}|${year}`;
+
+      if (existingKeys.has(dedupKey) || uploadedThisRun.has(dedupKey)) {
+        console.log(`  SKIP (already exists): ${title}`);
+        skipCount++;
+        continue;
+      }
+
+      try {
+        process.stdout.write(`  Uploading: ${title} ... `);
+
+        const pdfPath   = path.join(folderPath, pdf);
+        const publicUrl = await uploadToAzure(pdfPath, pdf);
+
+        await createPaper(token, {
+          title,
+          medium,
+          subject: subjectId,
+          grade:   OL_GRADE_ID,
+          year,
+          url:     publicUrl,
+        });
+
+        console.log("✓");
+        uploadedThisRun.add(dedupKey);
+        successCount++;
+      } catch (err) {
+        console.log(`✗ ERROR: ${err.message}`);
+        errorCount++;
+      }
+    }
+  }
+
+  console.log("\n=== Done ===");
+  console.log(`  ✓ Uploaded : ${successCount}`);
+  console.log(`  ⚠ Skipped  : ${skipCount}`);
+  console.log(`  ✗ Errors   : ${errorCount}`);
+}
+
+main().catch((err) => {
+  console.error("\nFatal error:", err.message);
+  process.exit(1);
+});

--- a/scripts/upload-ol-papers.mjs
+++ b/scripts/upload-ol-papers.mjs
@@ -26,8 +26,6 @@ const AZURE_ACCOUNT   = "tutormeuploads";
 const AZURE_CONTAINER = "uploads";
 const AZURE_KEY       = process.env.AZURE_STORAGE_KEY ?? "";
 
-const OL_GRADE_ID = "69d791dec6b695cea3b179e5"; // G.C.E. Ordinary Level (Grade 10-11)
-
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function prompt(question) {
@@ -137,8 +135,7 @@ function normalizeSubject(name) {
     .trim();
 }
 
-function findSubjectId(grades, subjectName) {
-  const grade = grades.find((g) => g.id === OL_GRADE_ID);
+function findSubjectId(grade, subjectName) {
   if (!grade?.subjects) return null;
   const normalized = normalizeSubject(subjectName);
   const match = grade.subjects.find((s) => {
@@ -186,8 +183,8 @@ async function main() {
 
   console.log("Fetching grades from API...");
   const grades = await fetchGrades(token);
-  const olGrade = grades.find((g) => g.id === OL_GRADE_ID);
-  if (!olGrade) throw new Error("O/L grade not found in API");
+  const olGrade = grades.find((g) => /ordinary level/i.test(g.title));
+  if (!olGrade) throw new Error("O/L grade not found in API — no grade with 'Ordinary Level' in title");
   console.log(`✓ Found O/L grade: ${olGrade.title} (${(olGrade.subjects ?? []).length} subjects)\n`);
 
   const folders = fs.readdirSync(PAPERS_DIR).filter((name) => {
@@ -212,7 +209,7 @@ async function main() {
     }
 
     const { subject, medium } = parsed;
-    const subjectId = findSubjectId(grades, subject);
+    const subjectId = findSubjectId(olGrade, subject);
 
     if (!subjectId) {
       const available = (olGrade.subjects ?? []).map((s) => s.title).join(", ") || "none";
@@ -252,7 +249,7 @@ async function main() {
           title,
           medium,
           subject: subjectId,
-          grade:   OL_GRADE_ID,
+          grade:   olGrade.id,
           year,
           url:     publicUrl,
         });

--- a/scripts/upload-papers.mjs
+++ b/scripts/upload-papers.mjs
@@ -1,0 +1,361 @@
+/**
+ * Bulk test paper uploader
+ * Usage: node scripts/upload-papers.mjs
+ *
+ * Reads grade folders from PAPERS_DIR, uploads each PDF to Azure Blob Storage,
+ * then creates a paper record via the backend API.
+ */
+
+import fs from "fs";
+import path from "path";
+import readline from "readline";
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+const API_BASE = "https://tutorme-backend-api-d7a6cjdkgnedbxf0.southeastasia-01.azurewebsites.net";
+const PAPERS_DIR = "D:/Download/2026.04.07";
+
+const AZURE_ACCOUNT   = "tutormeuploads";
+const AZURE_CONTAINER = "uploads";
+const AZURE_KEY       = process.env.AZURE_STORAGE_KEY ?? "";
+
+// Grade folder number → DB grade ID
+const GRADE_MAP = {
+  1: "69d79165c6b6954ecfb179bf",  // Grade 1–4 (Primary)
+  2: "69d79165c6b6954ecfb179bf",
+  3: "69d79165c6b6954ecfb179bf",
+  4: "69d79165c6b6954ecfb179bf",
+  5: "69d79186c6b6952f1ab179cf",  // Grade 5 Scholarship
+  6: "69d7918fc6b69553a3b179d3",  // Grade 6-9 (Secondary)
+  7: "69d7918fc6b69553a3b179d3",
+  8: "69d7918fc6b69553a3b179d3",
+  9: "69d7918fc6b69553a3b179d3",
+  10: "69d791dec6b695cea3b179e5", // G.C.E Ordinary Level (Grade 10-11)
+  11: "69d791dec6b695cea3b179e5",
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function prompt(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => rl.question(question, (ans) => { rl.close(); resolve(ans); }));
+}
+
+async function login(email, password, retries = 5) {
+  for (let i = 0; i < retries; i++) {
+    const res = await fetch(`${API_BASE}/v1/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    const text = await res.text();
+    if (text.startsWith("Too many")) {
+      const wait = (i + 1) * 10000;
+      console.log(`  Rate limited — waiting ${wait / 1000}s before retry...`);
+      await new Promise((r) => setTimeout(r, wait));
+      continue;
+    }
+    const data = JSON.parse(text);
+    if (!res.ok) throw new Error(`Login failed: ${data.message}`);
+    return data.tokens.access.token;
+  }
+  throw new Error("Login failed after retries — rate limited");
+}
+
+async function fetchGrades(token) {
+  const res = await fetch(`${API_BASE}/v1/grades?page=1&limit=50`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await res.json();
+  return data.results ?? [];
+}
+
+// Explicit aliases for folder names that don't fuzzy-match DB subject titles
+const SUBJECT_ALIAS = {
+  "environment related activities term test papers": "Environmental Studies",
+  "environment related activities 2025":            "Environmental Studies",
+  "environment related activitie":                  "Environmental Studies",
+  "environment related activities":                 "Environmental Studies",
+  "environment related":                            "Environmental Studies",
+};
+
+// Folder names sometimes use "&" or extra spaces; normalise before matching
+function normalizeSubject(name) {
+  return name
+    .toLowerCase()
+    .replace(/\s+/g, " ")          // collapse multiple spaces
+    .replace(/\s*&\s*/g, " and ")  // "Health & Physical" → "health and physical"
+    .trim();
+}
+
+function findSubjectId(grades, gradeId, subjectName) {
+  const grade = grades.find((g) => g.id === gradeId);
+  if (!grade?.subjects) return null;
+
+  // Check explicit alias first
+  const aliasedName = SUBJECT_ALIAS[subjectName.toLowerCase().trim()] ?? subjectName;
+  const normalized = normalizeSubject(aliasedName);
+
+  const match = grade.subjects.find((s) => {
+    const db = normalizeSubject(s.title);
+    return db === normalized || db.includes(normalized) || normalized.includes(db);
+  });
+  return match?.id ?? null;
+}
+
+// Generate SAS URL using HMAC-SHA256 (Azure Shared Key auth)
+async function generateSasUrl(blobName, fileType) {
+  const { createHmac } = await import("crypto");
+
+  const now = new Date();
+  const expires = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour
+
+  const toIso = (d) => d.toISOString().replace(/\.\d+Z$/, "Z");
+  const start = toIso(now);
+  const end   = toIso(expires);
+
+  const permissions = "cw";
+  const signedFields = [
+    permissions,  // signedPermissions
+    start,        // signedStart
+    end,          // signedExpiry
+    `/blob/${AZURE_ACCOUNT}/${AZURE_CONTAINER}/${blobName}`, // canonicalizedResource
+    "",           // signedIdentifier
+    "",           // signedIP
+    "https",      // signedProtocol
+    "2024-11-04", // signedVersion
+    "b",          // signedResource (blob)
+    "",           // signedSnapshotTime
+    "",           // signedEncryptionScope
+    "",           // rscc
+    "",           // rscd
+    "",           // rsce
+    "",           // rscl
+    fileType,     // rsct (Content-Type)
+  ];
+
+  const stringToSign = signedFields.join("\n");
+  const sig = createHmac("sha256", Buffer.from(AZURE_KEY, "base64"))
+    .update(stringToSign, "utf8")
+    .digest("base64");
+
+  const params = new URLSearchParams({
+    sp:  permissions,
+    st:  start,
+    se:  end,
+    spr: "https",
+    sv:  "2024-11-04",
+    sr:  "b",
+    rsct: fileType,
+    sig,
+  });
+
+  return `https://${AZURE_ACCOUNT}.blob.core.windows.net/${AZURE_CONTAINER}/${blobName}?${params}`;
+}
+
+async function uploadToAzure(filePath, fileName) {
+  const fileType = "application/pdf";
+  const blobName = `${Date.now()}-${fileName}`;
+  const sasUrl   = await generateSasUrl(blobName, fileType);
+
+  const fileBuffer = fs.readFileSync(filePath);
+
+  const res = await fetch(sasUrl, {
+    method: "PUT",
+    headers: {
+      "x-ms-blob-type": "BlockBlob",
+      "Content-Type": fileType,
+    },
+    body: fileBuffer,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Azure upload failed (${res.status}): ${text}`);
+  }
+
+  return sasUrl.split("?")[0]; // public URL without SAS token
+}
+
+async function fetchExistingKeys(token) {
+  const res = await fetch(`${API_BASE}/v1/papers?page=1&limit=10000`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await res.json();
+  return new Set(
+    (data.results ?? []).map((p) => {
+      const medium = p.medium?.id ?? p.medium ?? "";
+      return `${p.title.toLowerCase().trim()}|${medium.toLowerCase()}|${p.year ?? ""}`;
+    }),
+  );
+}
+
+async function createPaper(token, paper) {
+  const res = await fetch(`${API_BASE}/v1/papers`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(paper),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(`Create paper failed: ${JSON.stringify(data)}`);
+  return data;
+}
+
+// ─── Parsers ──────────────────────────────────────────────────────────────────
+
+function parseFolderName(folderName) {
+  // "Grade 6 Mathematics sinhala medium"
+  const match = folderName.match(/^Grade\s+(\d+)\s+(.+?)\s+(sinhala|english|tamil)\s+medium$/i);
+  if (!match) return null;
+  return {
+    gradeNumber: parseInt(match[1]),
+    subject: match[2].trim(),
+    medium: match[3].charAt(0).toUpperCase() + match[3].slice(1).toLowerCase(),
+  };
+}
+
+function parseFileName(fileName) {
+  // handles both:
+  // sri-lanka-grade-1-english-2019-3rd-term-test-paper-xxx.pdf
+  // north-western-province-grade-6-art-2019-3-term-test-paper-xxx.pdf
+  const yearMatch = fileName.match(/(\d{4})/);
+
+  const ordinalMatch = fileName.match(/(1st|2nd|3rd)/i);
+  const numericMatch = fileName.match(/-(\d)-term/i);
+
+  const ORDINAL = { "1": "1st", "2": "2nd", "3": "3rd" };
+
+  let term = null;
+  if (ordinalMatch) {
+    term = ordinalMatch[1].toLowerCase();
+  } else if (numericMatch) {
+    term = ORDINAL[numericMatch[1]] ?? null;
+  }
+
+  if (!yearMatch || !term) return null;
+  return { year: yearMatch[1], term };
+}
+
+function buildTitle(gradeNumber, subject, medium, term, year) {
+  return `Grade ${gradeNumber} ${subject} ${medium} Medium ${term} Term Test Paper ${year}`;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("=== TutorMe Paper Bulk Uploader ===\n");
+
+  const email    = process.argv[2] ?? await prompt("Admin email: ");
+  const password = process.argv[3] ?? await prompt("Admin password: ");
+
+  console.log("\nLogging in...");
+  const token = await login(email, password);
+  console.log("✓ Logged in\n");
+
+  console.log("Fetching grades from API...");
+  const grades = await fetchGrades(token);
+  console.log(`✓ Fetched ${grades.length} grades\n`);
+
+  const folders = fs.readdirSync(PAPERS_DIR).filter((name) => {
+    const full = path.join(PAPERS_DIR, name);
+    return fs.statSync(full).isDirectory() && /^Grade\s+\d+/i.test(name);
+  });
+
+  console.log(`Found ${folders.length} grade folders\n`);
+
+  console.log("Fetching existing paper titles to skip duplicates...");
+  const existingKeys = await fetchExistingKeys(token);
+  console.log(`✓ ${existingKeys.size} papers already in DB\n`);
+
+  // Also track what we've uploaded THIS run to skip duplicate files within the same folder
+  const uploadedThisRun = new Set();
+
+  let successCount = 0;
+  let skipCount    = 0;
+  let errorCount   = 0;
+
+  for (const folder of folders) {
+    const parsed = parseFolderName(folder);
+    if (!parsed) {
+      console.log(`  SKIP (can't parse folder): ${folder}`);
+      skipCount++;
+      continue;
+    }
+
+    const { gradeNumber, subject, medium } = parsed;
+    const gradeId = GRADE_MAP[gradeNumber];
+
+    if (!gradeId) {
+      console.log(`  SKIP (no grade mapping for Grade ${gradeNumber}): ${folder}`);
+      skipCount++;
+      continue;
+    }
+
+    const subjectId = findSubjectId(grades, gradeId, subject);
+    if (!subjectId) {
+      const grade = grades.find((g) => g.id === gradeId);
+      const available = (grade?.subjects ?? []).map((s) => s.title).join(", ") || "none";
+      console.log(`  SKIP (subject "${subject}" not found for Grade ${gradeNumber}). Available: ${available}`);
+      skipCount++;
+      continue;
+    }
+
+    const folderPath = path.join(PAPERS_DIR, folder);
+    const pdfs = fs.readdirSync(folderPath).filter((f) => f.toLowerCase().endsWith(".pdf"));
+
+    for (const pdf of pdfs) {
+      const fileParsed = parseFileName(pdf);
+      if (!fileParsed) {
+        console.log(`  SKIP (can't parse filename): ${pdf}`);
+        skipCount++;
+        continue;
+      }
+
+      const { year, term } = fileParsed;
+      const title = buildTitle(gradeNumber, subject, medium, term, year);
+      const dedupKey = `${title.toLowerCase().trim()}|${medium.toLowerCase()}|${year}`;
+
+      if (existingKeys.has(dedupKey) || uploadedThisRun.has(dedupKey)) {
+        console.log(`  SKIP (already exists): ${title}`);
+        skipCount++;
+        continue;
+      }
+
+      try {
+        process.stdout.write(`  Uploading: ${title} ... `);
+
+        const pdfPath   = path.join(folderPath, pdf);
+        const publicUrl = await uploadToAzure(pdfPath, pdf);
+
+        await createPaper(token, {
+          title,
+          medium,
+          subject: subjectId,
+          grade: gradeId,
+          year,
+          url: publicUrl,
+        });
+
+        console.log("✓");
+        uploadedThisRun.add(dedupKey);
+        successCount++;
+      } catch (err) {
+        console.log(`✗ ERROR: ${err.message}`);
+        errorCount++;
+      }
+    }
+  }
+
+  console.log("\n=== Done ===");
+  console.log(`  ✓ Uploaded : ${successCount}`);
+  console.log(`  ⚠ Skipped  : ${skipCount}`);
+  console.log(`  ✗ Errors   : ${errorCount}`);
+}
+
+main().catch((err) => {
+  console.error("\nFatal error:", err.message);
+  process.exit(1);
+});

--- a/scripts/upload-papers.mjs
+++ b/scripts/upload-papers.mjs
@@ -19,20 +19,24 @@ const AZURE_ACCOUNT   = "tutormeuploads";
 const AZURE_CONTAINER = "uploads";
 const AZURE_KEY       = process.env.AZURE_STORAGE_KEY ?? "";
 
-// Grade folder number → DB grade ID
-const GRADE_MAP = {
-  1: "69d79165c6b6954ecfb179bf",  // Grade 1–4 (Primary)
-  2: "69d79165c6b6954ecfb179bf",
-  3: "69d79165c6b6954ecfb179bf",
-  4: "69d79165c6b6954ecfb179bf",
-  5: "69d79186c6b6952f1ab179cf",  // Grade 5 Scholarship
-  6: "69d7918fc6b69553a3b179d3",  // Grade 6-9 (Secondary)
-  7: "69d7918fc6b69553a3b179d3",
-  8: "69d7918fc6b69553a3b179d3",
-  9: "69d7918fc6b69553a3b179d3",
-  10: "69d791dec6b695cea3b179e5", // G.C.E Ordinary Level (Grade 10-11)
-  11: "69d791dec6b695cea3b179e5",
-};
+// Build grade number → DB grade ID map from API grades by title matching
+function buildGradeMap(grades) {
+  const map = {};
+  for (const grade of grades) {
+    const title = grade.title.toLowerCase();
+    if (/primary/i.test(title)) {
+      for (const n of [1, 2, 3, 4]) map[n] ??= grade.id;
+    } else if (/grade 5|scholarship/i.test(title)) {
+      map[5] ??= grade.id;
+    } else if (/secondary/i.test(title)) {
+      for (const n of [6, 7, 8, 9]) map[n] ??= grade.id;
+    } else if (/ordinary level/i.test(title)) {
+      map[10] ??= grade.id;
+      map[11] ??= grade.id;
+    }
+  }
+  return map;
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -257,7 +261,8 @@ async function main() {
 
   console.log("Fetching grades from API...");
   const grades = await fetchGrades(token);
-  console.log(`✓ Fetched ${grades.length} grades\n`);
+  const gradeMap = buildGradeMap(grades);
+  console.log(`✓ Fetched ${grades.length} grades, mapped to grade numbers: ${Object.keys(gradeMap).join(", ") || "none"}\n`);
 
   const folders = fs.readdirSync(PAPERS_DIR).filter((name) => {
     const full = path.join(PAPERS_DIR, name);
@@ -286,7 +291,7 @@ async function main() {
     }
 
     const { gradeNumber, subject, medium } = parsed;
-    const gradeId = GRADE_MAP[gradeNumber];
+    const gradeId = gradeMap[gradeNumber];
 
     if (!gradeId) {
       console.log(`  SKIP (no grade mapping for Grade ${gradeNumber}): ${folder}`);


### PR DESCRIPTION
## Summary

- Add scraper scripts to bulk download GCE O/L and A/L past papers from govdoc.lk, organised by subject and medium
- Add uploader scripts to push downloaded PDFs to Azure Blob Storage and create paper records via the backend API
- Move Azure Storage key to `AZURE_STORAGE_KEY` environment variable (removed hardcoded secret)
- Update `.gitignore` to exclude `.claude/` directory

## Scripts

| Script | Purpose |
|---|---|
| `scrape-ol-papers.mjs` | Scrapes O/L papers from govdoc.lk |
| `upload-ol-papers.mjs` | Uploads O/L PDFs to Azure + creates DB records |
| `scrape-al-papers.mjs` | Scrapes A/L papers from govdoc.lk |
| `upload-al-papers.mjs` | Uploads A/L PDFs to Azure + creates DB records |

## Usage

```bash
# Set Azure key
$env:AZURE_STORAGE_KEY = "<key>"

# Scrape then upload
node scripts/scrape-ol-papers.mjs
node scripts/upload-ol-papers.mjs <email> <password>
Test plan
 Scripts run without errors locally
 PDFs upload successfully to Azure Blob Storage
 Paper records appear in the admin panel after upload