### PR TITLE
feat: request for tutor admin updates

### DIFF
--- a/src/app/(admin)/request-tutor/TutorsList.tsx
+++ b/src/app/(admin)/request-tutor/TutorsList.tsx
@@ -1,43 +1,310 @@
 "use client";
 
 import DataTable, { Column } from "@/components/tables/DataTable";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  CLASS_TYPE_OPTIONS,
+  TUTOR_MEDIUM_OPTIONS,
+  TUTOR_TYPE_OPTIONS,
+} from "@/configs/app-constants";
 import { TABLE_CONFIG } from "@/configs/table";
+import { useDebounce } from "@/hooks/useDebounce";
 import { useFetchGradesQuery } from "@/store/api/splits/grades";
-import { useFetchRequestForTutorsQuery } from "@/store/api/splits/request-tutor";
+import {
+  useFetchRequestForTutorsQuery,
+  useGenerateTutorMatchReportMutation,
+} from "@/store/api/splits/request-tutor";
+import { useFetchSubjectsQuery } from "@/store/api/splits/subjects";
+import { FetchRequestForTutor } from "@/types/request-types";
 import { RequestTutors } from "@/types/response-types";
-import { useMemo, useState } from "react";
+import { CheckCircle2, Loader2, Mail, Search, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
 import { AssignTutorDialog } from "./assignTutor";
 import { ChangeStatusDialog } from "./changeStatus";
 import { DeleteTutorRequest } from "./DeleteTutor";
+import {
+  formatTutorMatchReportSummaryText,
+  normalizeTutorMatchReportSummary,
+  type MatchReportSummary,
+} from "./match-report";
 import { ViewTutorRequests } from "./ViewTutor";
+
+type RequestTutorStatusFilter = "all" | "Pending" | "Rejected";
+
+type RequestTutorFilters = {
+  status: RequestTutorStatusFilter;
+  grade: string;
+  medium: string;
+  subject: string;
+  preferredTutorType: string;
+  preferredClassType: string;
+  assignedTutor: string;
+  duration: string;
+  frequency: string;
+};
+
+const INITIAL_FILTERS: RequestTutorFilters = {
+  status: "all",
+  grade: "all",
+  medium: "all",
+  subject: "all",
+  preferredTutorType: "all",
+  preferredClassType: "all",
+  assignedTutor: "",
+  duration: "",
+  frequency: "",
+};
+
+const REQUEST_TUTOR_STATUS_OPTIONS: Array<{
+  value: RequestTutorStatusFilter;
+  label: string;
+}> = [
+  { value: "all", label: "All statuses" },
+  { value: "Pending", label: "Pending" },
+  { value: "Rejected", label: "Rejected" },
+];
+
+const REQUEST_TUTOR_STATUS_CLASSES: Record<string, string> = {
+  Pending:
+    "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200",
+  Rejected:
+    "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200",
+};
+
+function RequestTutorStatusBadge({ status }: { status: string }) {
+  const normalizedStatus = status === "Rejected" ? "Rejected" : "Pending";
+  const className =
+    REQUEST_TUTOR_STATUS_CLASSES[normalizedStatus] ??
+    REQUEST_TUTOR_STATUS_CLASSES.Pending;
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold ${className}`}
+    >
+      {normalizedStatus}
+    </span>
+  );
+}
+
+function MatchReportAction({
+  requestId,
+  onSuccess,
+  lastSummary,
+}: {
+  requestId: string;
+  onSuccess: (requestId: string, summary: MatchReportSummary) => void;
+  lastSummary?: MatchReportSummary;
+}) {
+  const [generateTutorMatchReport, { isLoading }] =
+    useGenerateTutorMatchReportMutation();
+
+  const handleGenerate = async () => {
+    try {
+      const response = await generateTutorMatchReport({
+        requestId,
+      }).unwrap();
+      const summary = normalizeTutorMatchReportSummary(response);
+      onSuccess(requestId, summary);
+      const summaryText = formatTutorMatchReportSummaryText(summary);
+      toast.success(
+        summaryText
+          ? `Tutor match report sent successfully: ${summaryText}`
+          : "Tutor match report sent successfully",
+      );
+    } catch (error) {
+      console.error(error);
+      toast.error("Failed to generate tutor match report");
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleGenerate}
+        disabled={isLoading}
+        className="h-8 gap-2 px-3 text-xs"
+      >
+        {isLoading ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Mail className="h-3.5 w-3.5" />
+        )}
+        {isLoading ? "Generating" : "Report"}
+      </Button>
+
+      {lastSummary && (
+        <div className="max-w-[170px] text-center text-[11px] leading-4 text-emerald-700 dark:text-emerald-300">
+          <div className="flex items-center justify-center gap-1 font-medium">
+            <CheckCircle2 className="h-3 w-3" />
+            Sent
+          </div>
+          {lastSummary.adminEmail && (
+            <div className="truncate" title={lastSummary.adminEmail}>
+              {lastSummary.adminEmail}
+            </div>
+          )}
+          {lastSummary.blocks.length > 0 && (
+            <div
+              className="truncate"
+              title={formatTutorMatchReportSummaryText(lastSummary)}
+            >
+              {lastSummary.blocks
+                .map((block) => `${block.label}: ${block.matchedCount}`)
+                .join(", ")}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function RequestForTutorsList() {
   const [page, setPage] = useState<number>(TABLE_CONFIG.DEFAULT_PAGE);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [filters, setFilters] = useState<RequestTutorFilters>(INITIAL_FILTERS);
+  const [reportSummaries, setReportSummaries] = useState<
+    Record<string, MatchReportSummary>
+  >({});
   const limit = TABLE_CONFIG.DEFAULT_LIMIT;
 
-  const { data, isLoading, refetch } = useFetchRequestForTutorsQuery({
-    page,
-    limit,
-    sortBy: "createdAt:desc",
-  });
+  const debouncedSearchTerm = useDebounce(searchTerm, 400);
+  const debouncedAssignedTutor = useDebounce(filters.assignedTutor, 400);
+  const debouncedDuration = useDebounce(filters.duration, 400);
+  const debouncedFrequency = useDebounce(filters.frequency, 400);
+
+  const { data, isLoading, refetch } = useFetchRequestForTutorsQuery(
+    useMemo<FetchRequestForTutor>(
+      () => ({
+        page,
+        limit,
+        sortBy: "createdAt:desc",
+        ...(debouncedSearchTerm.trim()
+          ? { search: debouncedSearchTerm.trim() }
+          : {}),
+        ...(filters.status !== "all" ? { status: filters.status } : {}),
+        ...(filters.grade !== "all" ? { grade: filters.grade } : {}),
+        ...(filters.medium !== "all" ? { medium: filters.medium } : {}),
+        ...(filters.subject !== "all" ? { subject: filters.subject } : {}),
+        ...(filters.preferredTutorType !== "all"
+          ? { preferredTutorType: filters.preferredTutorType }
+          : {}),
+        ...(filters.preferredClassType !== "all"
+          ? { preferredClassType: filters.preferredClassType }
+          : {}),
+        ...(debouncedAssignedTutor.trim()
+          ? { assignedTutor: debouncedAssignedTutor.trim() }
+          : {}),
+        ...(debouncedDuration.trim()
+          ? { duration: debouncedDuration.trim() }
+          : {}),
+        ...(debouncedFrequency.trim()
+          ? { frequency: debouncedFrequency.trim() }
+          : {}),
+      }),
+      [
+        debouncedAssignedTutor,
+        debouncedDuration,
+        debouncedFrequency,
+        debouncedSearchTerm,
+        filters.grade,
+        filters.medium,
+        filters.preferredClassType,
+        filters.preferredTutorType,
+        filters.status,
+        filters.subject,
+        limit,
+        page,
+      ],
+    ),
+  );
+
   const { data: gradesData, isFetching: isFetchingGrades } =
     useFetchGradesQuery({
       page: 1,
       limit: 10000,
+      sortBy: "title:asc",
+    });
+  const { data: subjectsData, isFetching: isFetchingSubjects } =
+    useFetchSubjectsQuery({
+      page: 1,
+      limit: 10000,
+      sortBy: "title:asc",
     });
 
   const tutors: RequestTutors[] = data?.results || [];
   const totalPages = data?.totalPages || 1;
   const totalResults = data?.totalResults || tutors.length;
-  const gradeTitleById = useMemo(
+
+  const gradeOptions = useMemo(
     () =>
-      new Map(
-        (gradesData?.results || []).map((grade) => [grade.id, grade.title]),
-      ),
+      (gradesData?.results || []).map((grade) => ({
+        value: grade.id,
+        label: grade.title,
+      })),
     [gradesData?.results],
   );
 
+  const subjectOptions = useMemo(
+    () =>
+      (subjectsData?.results || []).map((subject) => ({
+        value: subject.id,
+        label: subject.title,
+      })),
+    [subjectsData?.results],
+  );
+
+  useEffect(() => {
+    setPage(TABLE_CONFIG.DEFAULT_PAGE);
+  }, [
+    debouncedAssignedTutor,
+    debouncedDuration,
+    debouncedFrequency,
+    debouncedSearchTerm,
+    filters.grade,
+    filters.medium,
+    filters.preferredClassType,
+    filters.preferredTutorType,
+    filters.status,
+    filters.subject,
+  ]);
+
   const handlePageChange = (newPage: number) => setPage(newPage);
+
+  const updateFilter = <K extends keyof RequestTutorFilters>(
+    key: K,
+    value: RequestTutorFilters[K],
+  ) => {
+    setFilters((current) => ({ ...current, [key]: value }));
+  };
+
+  const handleResetFilters = () => {
+    setSearchTerm("");
+    setFilters(INITIAL_FILTERS);
+    setPage(TABLE_CONFIG.DEFAULT_PAGE);
+  };
+
+  const handleReportSuccess = (
+    requestId: string,
+    summary: MatchReportSummary,
+  ) => {
+    setReportSummaries((current) => ({
+      ...current,
+      [requestId]: summary,
+    }));
+  };
 
   const getSafeValue = (value: unknown, fallback = "N/A") => {
     if (value === undefined || value === null) {
@@ -64,17 +331,7 @@ export default function RequestForTutorsList() {
       );
     }
 
-    const gradeId = getSafeValue(grade, "");
-    if (!gradeId) {
-      return "";
-    }
-
-    const gradeTitle = gradeTitleById.get(gradeId);
-    if (gradeTitle) {
-      return gradeTitle;
-    }
-
-    return isFetchingGrades ? "Loading grade..." : "Unknown grade";
+    return getSafeValue(grade, "");
   };
 
   const columns = useMemo<Column<RequestTutors>[]>(
@@ -121,6 +378,19 @@ export default function RequestForTutorsList() {
         ),
       },
       {
+        key: "medium",
+        header: "Medium",
+        className: "min-w-[120px] max-w-[150px] truncate overflow-hidden",
+        render: (row: RequestTutors) => (
+          <span
+            title={row.medium || "No medium"}
+            className={`truncate block ${!row.medium ? "text-gray-400 italic" : ""}`}
+          >
+            {getSafeValue(row.medium, "No medium")}
+          </span>
+        ),
+      },
+      {
         key: "grade",
         header: "Grade",
         className: "min-w-[280px] max-w-[360px] whitespace-normal",
@@ -152,13 +422,20 @@ export default function RequestForTutorsList() {
         header: "Change Status",
         align: "center",
         className:
-          "min-w-[140px] max-w-[140px] sticky right-[250px] z-20 bg-white dark:bg-gray-900",
+          "min-w-[190px] max-w-[190px] sticky right-[250px] z-20 bg-white dark:bg-gray-900",
         render: (row: RequestTutors) => (
-          <ChangeStatusDialog
-            requestId={row.id}
-            currentStatus={row.status}
-            onStatusChange={() => refetch()}
-          />
+          <div className="flex flex-col items-center gap-2">
+            <div className="flex items-center justify-center gap-2">
+              <RequestTutorStatusBadge status={row.status} />
+              <ChangeStatusDialog
+                requestId={row.id}
+                currentStatus={
+                  row.status === "Rejected" ? "Rejected" : "Pending"
+                }
+                onStatusChange={() => refetch()}
+              />
+            </div>
+          </div>
         ),
       },
       {
@@ -196,19 +473,207 @@ export default function RequestForTutorsList() {
         render: (row: RequestTutors) => <DeleteTutorRequest tutorId={row.id} />,
       },
     ],
-    [gradeTitleById, isFetchingGrades, refetch],
+    [refetch],
   );
 
   return (
-    <DataTable
-      columns={columns}
-      data={tutors}
-      page={page}
-      totalPages={totalPages}
-      onPageChange={handlePageChange}
-      totalResults={totalResults}
-      limit={limit}
-      isLoading={isLoading}
-    />
+    <div className="space-y-4">
+      <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-white/10 dark:bg-gray-900">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-1">
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white/90">
+              Request filters
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-white/60">
+              Search tutor requests and narrow them by status, grade, medium,
+              tutor type, and class type.
+            </p>
+          </div>
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleResetFilters}
+            className="w-full gap-2 lg:w-auto"
+          >
+            <X className="h-4 w-4" />
+            Clear filters
+          </Button>
+        </div>
+
+        <div className="mt-4 grid gap-4 lg:grid-cols-3">
+          <div className="space-y-1.5 lg:col-span-3">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Search
+            </label>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+              <Input
+                type="text"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Search by name, email, city, district, phone number, subject, or assigned tutor"
+                className="h-11 w-full pl-10 pr-4"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Status
+            </label>
+            <Select
+              value={filters.status}
+              onValueChange={(value) =>
+                updateFilter("status", value as RequestTutorStatusFilter)
+              }
+            >
+              <SelectTrigger className="h-11 min-h-11 w-full">
+                <SelectValue placeholder="Filter by status" />
+              </SelectTrigger>
+              <SelectContent>
+                {REQUEST_TUTOR_STATUS_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Grade
+            </label>
+            <Select
+              value={filters.grade}
+              onValueChange={(value) => updateFilter("grade", value)}
+            >
+              <SelectTrigger
+                className="h-11 min-h-11 w-full"
+                isLoading={isFetchingGrades}
+              >
+                <SelectValue placeholder="Filter by grade" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All grades</SelectItem>
+                {gradeOptions.map((grade) => (
+                  <SelectItem key={grade.value} value={grade.value}>
+                    {grade.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Medium
+            </label>
+            <Select
+              value={filters.medium}
+              onValueChange={(value) => updateFilter("medium", value)}
+            >
+              <SelectTrigger className="h-11 min-h-11 w-full">
+                <SelectValue placeholder="Filter by medium" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All mediums</SelectItem>
+                {TUTOR_MEDIUM_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.text}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Subject
+            </label>
+            <Select
+              value={filters.subject}
+              onValueChange={(value) => updateFilter("subject", value)}
+            >
+              <SelectTrigger
+                className="h-11 min-h-11 w-full"
+                isLoading={isFetchingSubjects}
+              >
+                <SelectValue placeholder="Filter by subject" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All subjects</SelectItem>
+                {subjectOptions.map((subject) => (
+                  <SelectItem key={subject.value} value={subject.value}>
+                    {subject.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Preferred tutor type
+            </label>
+            <Select
+              value={filters.preferredTutorType}
+              onValueChange={(value) =>
+                updateFilter("preferredTutorType", value)
+              }
+            >
+              <SelectTrigger className="h-11 min-h-11 w-full">
+                <SelectValue placeholder="Filter by tutor type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All tutor types</SelectItem>
+                {TUTOR_TYPE_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.text}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Preferred class type
+            </label>
+            <Select
+              value={filters.preferredClassType}
+              onValueChange={(value) =>
+                updateFilter("preferredClassType", value)
+              }
+            >
+              <SelectTrigger className="h-11 min-h-11 w-full">
+                <SelectValue placeholder="Filter by class type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All class types</SelectItem>
+                {CLASS_TYPE_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.text}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={tutors}
+        page={page}
+        totalPages={totalPages}
+        onPageChange={handlePageChange}
+        totalResults={totalResults}
+        limit={limit}
+        isLoading={isLoading}
+        emptyMessage="No tutor requests found for the current filters."
+      />
+    </div>
   );
 }

--- a/src/app/(admin)/request-tutor/ViewTutor.tsx
+++ b/src/app/(admin)/request-tutor/ViewTutor.tsx
@@ -5,6 +5,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -12,10 +13,19 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { useFetchGradeByIdQuery } from "@/store/api/splits/grades";
-import { useFetchRequestForTutorsByIdQuery } from "@/store/api/splits/request-tutor";
+import {
+  useFetchRequestForTutorsByIdQuery,
+  useGenerateTutorMatchReportMutation,
+} from "@/store/api/splits/request-tutor";
 import { useFetchSubjectsQuery } from "@/store/api/splits/subjects";
-import { Eye } from "lucide-react";
+import { CheckCircle2, Eye, Loader2, Mail } from "lucide-react";
 import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import {
+  formatTutorMatchReportSummaryText,
+  normalizeTutorMatchReportSummary,
+  type MatchReportSummary,
+} from "./match-report";
 
 interface ViewTutorProps {
   tutorId: string;
@@ -23,6 +33,11 @@ interface ViewTutorProps {
 
 export function ViewTutorRequests({ tutorId }: ViewTutorProps) {
   const [open, setOpen] = useState(false);
+  const [reportSummary, setReportSummary] = useState<MatchReportSummary | null>(
+    null,
+  );
+  const [generateTutorMatchReport, { isLoading: isGeneratingReport }] =
+    useGenerateTutorMatchReportMutation();
 
   const { data: tutor, isLoading } = useFetchRequestForTutorsByIdQuery(
     tutorId,
@@ -160,142 +175,226 @@ export function ViewTutorRequests({ tutorId }: ViewTutorProps) {
     return isFetchingSubjects ? "Loading subject..." : "Unknown subject";
   };
 
+  const handleGenerateTutorMatchReport = async () => {
+    try {
+      const response = await generateTutorMatchReport({
+        requestId: tutorId,
+      }).unwrap();
+      const summary = normalizeTutorMatchReportSummary(response);
+      setReportSummary(summary);
+      toast.success(
+        `Tutor match report sent successfully${formatTutorMatchReportSummaryText(summary) ? `: ${formatTutorMatchReportSummaryText(summary)}` : ""}`,
+      );
+    } catch (error) {
+      console.error(error);
+      toast.error("Failed to generate tutor match report");
+    }
+  };
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Eye className="cursor-pointer text-blue-500 hover:text-blue-700" />
       </DialogTrigger>
 
-      <DialogContent className="sm:max-w-[625px] max-h-[80vh] overflow-y-auto bg-white dark:bg-gray-800 dark:text-white/90 scrollbar-thin">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[625px] max-h-[80vh] overflow-hidden bg-white dark:bg-gray-800 dark:text-white/90 p-0">
+        <DialogHeader className="sticky top-0 z-10 bg-white dark:bg-gray-800 px-6 pt-6 pb-4 border-b">
           <DialogTitle>Tutor Request Details</DialogTitle>
+          <DialogDescription>
+            Review the request details, generate a tutor match report, and
+            inspect the suggested tutor blocks.
+          </DialogDescription>
         </DialogHeader>
-
-        {isLoading && (
-          <div className="text-sm text-gray-500 dark:text-white/70">
-            Loading request details...
-          </div>
-        )}
-
-        <div className="grid gap-4">
-          <div className="grid gap-3">
-            <Label>Full Name</Label>
-            <div className={displayFieldClass}>{getSafeValue(tutor?.name)}</div>
-          </div>
-
-          <div className="grid gap-3">
-            <Label>Email</Label>
-            <div className={displayFieldClass}>
-              {getSafeValue(tutor?.email)}
+        <div className="max-h-[calc(80vh-170px)] overflow-y-auto px-6 py-4 scrollbar-thin">
+          {isLoading && (
+            <div className="text-sm text-gray-500 dark:text-white/70">
+              Loading request details...
             </div>
-          </div>
+          )}
 
-          <div className="grid gap-3">
-            <Label>Phone Number</Label>
-            <div className={displayFieldClass}>
-              {getSafeValue(tutor?.phoneNumber)}
+          <div className="grid gap-4">
+            <div className="grid gap-3">
+              <Label>Full Name</Label>
+              <div className={displayFieldClass}>
+                {getSafeValue(tutor?.name)}
+              </div>
             </div>
-          </div>
 
-          <div className="grid gap-3">
-            <Label>Medium</Label>
-            <div className={displayFieldClass}>
-              {getSafeValue(tutor?.medium)}
+            <div className="grid gap-3">
+              <Label>Email</Label>
+              <div className={displayFieldClass}>
+                {getSafeValue(tutor?.email)}
+              </div>
             </div>
-          </div>
 
-          <div className="grid gap-3">
-            <Label>District / City</Label>
-            <div className={displayFieldClass}>
-              {[
-                getSafeValue(tutor?.district, ""),
-                getSafeValue(tutor?.city, ""),
-              ]
-                .filter(Boolean)
-                .join(", ") || "N/A"}
+            <div className="grid gap-3">
+              <Label>Phone Number</Label>
+              <div className={displayFieldClass}>
+                {getSafeValue(tutor?.phoneNumber)}
+              </div>
             </div>
-          </div>
 
-          <div className="grid gap-3">
-            <Label>Grade</Label>
-            <div className={displayFieldClass}>
-              {getGradeDisplayValue(tutor?.grade) || (
-                <span className="text-gray-400 italic">No grade</span>
-              )}
+            <div className="grid gap-3">
+              <Label>Medium</Label>
+              <div className={displayFieldClass}>
+                {getSafeValue(tutor?.medium)}
+              </div>
             </div>
-          </div>
 
-          <div className="grid gap-3">
-            <Label>Status</Label>
-            <div className={displayFieldClass}>
-              {getSafeValue(tutor?.status)}
+            <div className="grid gap-3">
+              <Label>District / City</Label>
+              <div className={displayFieldClass}>
+                {[
+                  getSafeValue(tutor?.district, ""),
+                  getSafeValue(tutor?.city, ""),
+                ]
+                  .filter(Boolean)
+                  .join(", ") || "N/A"}
+              </div>
             </div>
-          </div>
 
-          <div className="grid gap-3">
-            <Label>Tutors</Label>
-            <div className="flex flex-col gap-2">
-              {Array.isArray(tutor?.tutors) && tutor.tutors.length ? (
-                tutor.tutors.map((t, idx) => {
-                  const assignedTutorLabel = getAssignedTutorLabel(
-                    t.assignedTutor,
-                  );
+            <div className="grid gap-3">
+              <Label>Grade</Label>
+              <div className={displayFieldClass}>
+                {getGradeDisplayValue(tutor?.grade) || (
+                  <span className="text-gray-400 italic">No grade</span>
+                )}
+              </div>
+            </div>
 
-                  return (
-                    <div
-                      key={t._id || idx}
-                      className="p-3 border rounded space-y-1 bg-gray-50 dark:bg-gray-700"
-                    >
-                      <div>
-                        Subject:{" "}
-                        <span className={tagClass}>
-                          {getSubjectDisplayValue(t.subject)}
-                        </span>
-                      </div>
+            <div className="grid gap-3">
+              <Label>Status</Label>
+              <div className={displayFieldClass}>
+                {getSafeValue(tutor?.status)}
+              </div>
+            </div>
 
-                      {assignedTutorLabel && (
+            <div className="grid gap-3">
+              <Label>Tutors</Label>
+              <div className="flex flex-col gap-2">
+                {Array.isArray(tutor?.tutors) && tutor.tutors.length ? (
+                  tutor.tutors.map((t, idx) => {
+                    const assignedTutorLabel = getAssignedTutorLabel(
+                      t.assignedTutor,
+                    );
+
+                    return (
+                      <div
+                        key={t._id || idx}
+                        className="p-3 border rounded space-y-1 bg-gray-50 dark:bg-gray-700"
+                      >
                         <div>
-                          Assigned Tutor:{" "}
-                          <span
-                            className={`${tagClass} bg-green-100 dark:bg-green-800 text-green-800 dark:text-green-200`}
-                          >
-                            {assignedTutorLabel}
+                          Subject:{" "}
+                          <span className={tagClass}>
+                            {getSubjectDisplayValue(t.subject)}
                           </span>
                         </div>
-                      )}
 
-                      {t.preferredTutorType && (
+                        {assignedTutorLabel && (
+                          <div>
+                            Assigned Tutor:{" "}
+                            <span
+                              className={`${tagClass} bg-green-100 dark:bg-green-800 text-green-800 dark:text-green-200`}
+                            >
+                              {assignedTutorLabel}
+                            </span>
+                          </div>
+                        )}
+
+                        {t.preferredTutorType && (
+                          <div>
+                            Preferred Type:{" "}
+                            <strong>
+                              {getSafeValue(t.preferredTutorType)}
+                            </strong>
+                          </div>
+                        )}
                         <div>
-                          Preferred Type:{" "}
-                          <strong>{getSafeValue(t.preferredTutorType)}</strong>
+                          Duration: <strong>{getSafeValue(t.duration)}</strong>
                         </div>
-                      )}
-                      <div>
-                        Duration: <strong>{getSafeValue(t.duration)}</strong>
+                        <div>
+                          Frequency:{" "}
+                          <strong>{getSafeValue(t.frequency)}</strong>
+                        </div>
                       </div>
-                      <div>
-                        Frequency: <strong>{getSafeValue(t.frequency)}</strong>
-                      </div>
-                    </div>
-                  );
-                })
-              ) : (
-                <span className="text-gray-400 italic">No tutors</span>
+                    );
+                  })
+                ) : (
+                  <span className="text-gray-400 italic">No tutors</span>
+                )}
+              </div>
+            </div>
+
+            <div className="grid gap-3">
+              <Label>Created At</Label>
+              <div className={displayFieldClass}>
+                {tutor?.createdAt
+                  ? new Date(tutor.createdAt).toLocaleString()
+                  : "N/A"}
+              </div>
+            </div>
+          </div>
+          {reportSummary && (
+            <div className="grid mt-4 gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-4 dark:border-emerald-900 dark:bg-emerald-950/30">
+              <div className="flex items-center gap-2 text-emerald-700 dark:text-emerald-300">
+                <CheckCircle2 className="h-4 w-4" />
+                <p className="text-sm font-semibold">Tutor Match Report sent</p>
+              </div>
+              {reportSummary.adminEmail && (
+                <p className="text-sm text-emerald-800 dark:text-emerald-200">
+                  Admin email:{" "}
+                  <span className="font-medium">
+                    {reportSummary.adminEmail}
+                  </span>
+                </p>
               )}
+              {reportSummary.message && (
+                <p className="text-sm text-emerald-800 dark:text-emerald-200">
+                  {reportSummary.message}
+                </p>
+              )}
+              <div className="space-y-2">
+                {reportSummary.blocks.length > 0 ? (
+                  reportSummary.blocks.map((block) => (
+                    <div
+                      key={`${block.label}-${block.matchedCount}`}
+                      className="flex items-center justify-between rounded-md bg-white/80 px-3 py-2 text-sm text-emerald-950 dark:bg-emerald-900/30 dark:text-emerald-100"
+                    >
+                      <span className="font-medium">{block.label}</span>
+                      <span>
+                        {block.matchedCount} matched tutor
+                        {block.matchedCount === 1 ? "" : "s"}
+                      </span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-emerald-800 dark:text-emerald-200">
+                    The report was generated, but the response did not include
+                    block-level counts.
+                  </p>
+                )}
+              </div>
             </div>
-          </div>
-
-          <div className="grid gap-3">
-            <Label>Created At</Label>
-            <div className={displayFieldClass}>
-              {tutor?.createdAt
-                ? new Date(tutor.createdAt).toLocaleString()
-                : "N/A"}
-            </div>
-          </div>
+          )}
         </div>
+        <DialogFooter className="sticky bottom-0 z-10 bg-white dark:bg-gray-800 px-6 py-4 border-t">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleGenerateTutorMatchReport}
+            disabled={isGeneratingReport || isLoading}
+            className="gap-2"
+          >
+            {isGeneratingReport ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Mail className="h-4 w-4" />
+            )}
+            {isGeneratingReport
+              ? "Generating..."
+              : "Generate Tutor Match Report"}
+          </Button>
 
-        <DialogFooter>
           <DialogClose asChild>
             <Button variant="outline">Close</Button>
           </DialogClose>

--- a/src/app/(admin)/request-tutor/changeStatus.tsx
+++ b/src/app/(admin)/request-tutor/changeStatus.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -17,12 +18,12 @@ import {
 } from "@/components/ui/select";
 import { useUpdateStatusMutation } from "@/store/api/splits/request-tutor";
 import { Edit } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
 
 interface ChangeStatusDialogProps {
   requestId: string;
-  currentStatus: "Pending" | "Approved" | "Tutor Assigned";
+  currentStatus: "Pending" | "Rejected";
   onStatusChange?: () => void;
 }
 
@@ -33,13 +34,48 @@ export function ChangeStatusDialog({
 }: ChangeStatusDialogProps) {
   const [open, setOpen] = useState(false);
   const [status, setStatus] = useState(currentStatus);
-  const [updateStatus] = useUpdateStatusMutation();
+  const [rejectionReason, setRejectionReason] = useState("");
+  const [validationError, setValidationError] = useState("");
+  const [updateStatus, { isLoading }] = useUpdateStatusMutation();
+  const rejectionReasonRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const isRejected = status === "Rejected";
+  const isSaveDisabled = useMemo(() => {
+    if (status === "Rejected") {
+      return rejectionReason.trim().length === 0;
+    }
+
+    return false;
+  }, [rejectionReason, status]);
+
+  useEffect(() => {
+    if (open) {
+      setStatus(currentStatus);
+      setRejectionReason("");
+      setValidationError("");
+    }
+  }, [currentStatus, open]);
 
   const handleSave = async () => {
+    const nextRejectionReason = rejectionReasonRef.current?.value.trim() || rejectionReason.trim();
+
+    if (status === "Rejected" && !nextRejectionReason) {
+      setValidationError("Rejection reason is required when rejecting a tutor request.");
+      return;
+    }
+
     try {
-      await updateStatus({ requestId, status }).unwrap();
+      await updateStatus({
+        requestId,
+        status,
+        ...(status === "Rejected"
+          ? { rejectionReason: nextRejectionReason }
+          : {}),
+      }).unwrap();
       toast.success("Status updated successfully");
       setOpen(false);
+      setRejectionReason("");
+      setValidationError("");
       onStatusChange?.();
     } catch (err) {
       console.error(err);
@@ -56,31 +92,73 @@ export function ChangeStatusDialog({
       <DialogContent className="sm:max-w-[400px]">
         <DialogHeader>
           <DialogTitle>Change Request Status</DialogTitle>
+          <DialogDescription>
+            Leave the request pending or reject it with a reason that will be emailed to the requester.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="flex flex-col gap-4 mt-4">
           <label>Status</label>
           <Select
             value={status}
-            onValueChange={(val) =>
-              setStatus(val as "Pending" | "Approved" | "Tutor Assigned")
-            }
+            onValueChange={(val) => {
+              const nextStatus = val as "Pending" | "Rejected";
+              setStatus(nextStatus);
+
+              if (nextStatus === "Pending") {
+                setRejectionReason("");
+              }
+            }}
           >
             <SelectTrigger className="w-full">
               <SelectValue placeholder="Select status" />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="Pending">Pending</SelectItem>
-              <SelectItem value="Approved">Approved</SelectItem>
-              <SelectItem value="Tutor Assigned">Tutor Assigned</SelectItem>
+              <SelectItem value="Rejected">Rejected</SelectItem>
             </SelectContent>
           </Select>
 
+          {isRejected && (
+            <div className="flex flex-col gap-2">
+              <label htmlFor="rejectionReason">Rejection reason</label>
+              <textarea
+                id="rejectionReason"
+                ref={rejectionReasonRef}
+                value={rejectionReason}
+                onChange={(event) => {
+                  setRejectionReason(event.target.value);
+                  if (validationError) {
+                    setValidationError("");
+                  }
+                }}
+                placeholder="Explain why this request was rejected"
+                rows={4}
+                className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm outline-none focus:border-blue-500 dark:border-gray-700 dark:bg-gray-900"
+              />
+              <p className="text-xs text-gray-500">
+                This reason will be emailed to the requester.
+              </p>
+            </div>
+          )}
+
+          {validationError && (
+            <p className="text-sm text-red-600 dark:text-red-400">
+              {validationError}
+            </p>
+          )}
+
           <div className="flex justify-end gap-2 mt-4">
-            <Button variant="outline" onClick={() => setOpen(false)}>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
               Cancel
             </Button>
-            <Button onClick={handleSave}>Save</Button>
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={isSaveDisabled || isLoading}
+            >
+              {isLoading ? "Saving..." : "Save"}
+            </Button>
           </div>
         </div>
       </DialogContent>

--- a/src/app/(admin)/request-tutor/match-report.ts
+++ b/src/app/(admin)/request-tutor/match-report.ts
@@ -1,0 +1,124 @@
+export type MatchBlockSummary = {
+  label: string;
+  matchedCount: number;
+};
+
+export type MatchReportSummary = {
+  adminEmail?: string;
+  message?: string;
+  blocks: MatchBlockSummary[];
+};
+
+const unwrapRecord = (value: unknown): Record<string, unknown> => {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const record = value as Record<string, unknown>;
+
+  if (record.data && typeof record.data === "object") {
+    return record.data as Record<string, unknown>;
+  }
+
+  if (record.result && typeof record.result === "object") {
+    return record.result as Record<string, unknown>;
+  }
+
+  return record;
+};
+
+export const normalizeTutorMatchReportSummary = (
+  response: unknown,
+): MatchReportSummary => {
+  const record = unwrapRecord(response);
+  const adminRecord =
+    record.admin && typeof record.admin === "object"
+      ? (record.admin as Record<string, unknown>)
+      : undefined;
+
+  const adminEmail =
+    typeof record.adminEmail === "string"
+      ? record.adminEmail
+      : typeof record.admin_email === "string"
+        ? record.admin_email
+        : typeof record.email === "string"
+          ? record.email
+          : typeof record.generatedByEmail === "string"
+            ? record.generatedByEmail
+            : typeof adminRecord?.email === "string"
+              ? String(adminRecord.email)
+              : undefined;
+
+  const rawBlocks =
+    (Array.isArray(record.blocks) && record.blocks) ||
+    (Array.isArray(record.matchBlocks) && record.matchBlocks) ||
+    (Array.isArray(record.tutorBlocks) && record.tutorBlocks) ||
+    (Array.isArray(record.results) && record.results) ||
+    [];
+
+  const blocks = rawBlocks.map((block, index) => {
+    const blockRecord =
+      block && typeof block === "object" ? (block as Record<string, unknown>) : {};
+
+    const matchedTutors =
+      (Array.isArray(blockRecord.matchedTutors) && blockRecord.matchedTutors) ||
+      (Array.isArray(blockRecord.matches) && blockRecord.matches) ||
+      (Array.isArray(blockRecord.tutors) && blockRecord.tutors) ||
+      [];
+
+    const matchedCount =
+      Number(blockRecord.matchedCount) ||
+      Number(blockRecord.count) ||
+      Number(blockRecord.totalMatchedTutors) ||
+      matchedTutors.length ||
+      0;
+
+    const labelSource =
+      typeof blockRecord.subject === "string"
+        ? blockRecord.subject
+        : typeof blockRecord.subjectTitle === "string"
+          ? blockRecord.subjectTitle
+          : typeof blockRecord.title === "string"
+            ? blockRecord.title
+            : typeof blockRecord.name === "string"
+              ? blockRecord.name
+              : typeof blockRecord.blockName === "string"
+                ? blockRecord.blockName
+                : undefined;
+
+    return {
+      label: labelSource ? String(labelSource) : `Block ${index + 1}`,
+      matchedCount,
+    };
+  });
+
+  return {
+    adminEmail,
+    message: typeof record.message === "string" ? record.message : undefined,
+    blocks,
+  };
+};
+
+export const formatTutorMatchReportSummaryText = (
+  summary: MatchReportSummary,
+): string => {
+  const parts: string[] = [];
+
+  if (summary.adminEmail) {
+    parts.push(`Admin: ${summary.adminEmail}`);
+  }
+
+  if (summary.blocks.length > 0) {
+    parts.push(
+      summary.blocks
+        .map((block) => `${block.label}: ${block.matchedCount}`)
+        .join(", "),
+    );
+  }
+
+  if (summary.message) {
+    parts.push(summary.message);
+  }
+
+  return parts.join(" | ");
+};

--- a/src/app/(admin)/request-tutor/page.tsx
+++ b/src/app/(admin)/request-tutor/page.tsx
@@ -3,7 +3,7 @@ import RequestForTutorsList from "./TutorsList";
 
 export const metadata: Metadata = {
   title: "Admin | Tuition Lanka",
-  description: "Manage tutors",
+  description: "Manage tutor requests",
 };
 
 export default function TutorsPage() {

--- a/src/app/(full-width-pages)/(auth)/forgot-password/page.tsx
+++ b/src/app/(full-width-pages)/(auth)/forgot-password/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function ForgotPasswordPage() {
+  redirect("/signin");
+}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -4,7 +4,7 @@ import { useAuthContext } from "@/context";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
-const publicRoutes = ["/signin", "/signup", "/reset-password"];
+const publicRoutes = ["/signin", "/signup", "/forgot-password", "/reset-password"];
 
 export default function ProtectedRoute({
   children,

--- a/src/components/auth/form-forgot-password/index.tsx
+++ b/src/components/auth/form-forgot-password/index.tsx
@@ -1,52 +1,89 @@
+"use client";
+
 import InputText from "@/components/shared/input-text";
 import SubmitButton from "@/components/shared/submit-button";
+import { useForgotPasswordMutation } from "@/store/api/splits/auth";
+import { ForgotPasswordRequest } from "@/types/request-types";
+import { getErrorInApiResult } from "@/utils/api";
 import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
+import toast from "react-hot-toast";
 import { ForgotPasswordSchema, forgotPasswordSchema } from "./schema";
 
-type Props = {
-  onLoginClick: () => void;
-};
-
-const FormForgotPassword = ({ onLoginClick }: Props) => {
-  const forgotPasswordForm = useForm({
+const FormForgotPassword = () => {
+  const [sentEmail, setSentEmail] = useState("");
+  const [forgotPassword, { isLoading }] = useForgotPasswordMutation();
+  const forgotPasswordForm = useForm<ForgotPasswordSchema>({
     resolver: zodResolver(forgotPasswordSchema),
-    defaultValues: {} as ForgotPasswordSchema,
+    defaultValues: {
+      email: "",
+    },
     mode: "onChange",
   });
 
-  const onSubmit = (data: ForgotPasswordSchema) => {
-    console.log("Form Submitted", data);
+  const onSubmit = async (data: ForgotPasswordSchema) => {
+    const payload: ForgotPasswordRequest = { email: data.email };
+    const result = await forgotPassword(payload);
+    const error = getErrorInApiResult(result);
+
+    if (error) {
+      toast.error(error);
+      return;
+    }
+
+    setSentEmail(data.email);
+    toast.success(result.data?.message ?? "Reset link request sent successfully.");
+    forgotPasswordForm.reset({ email: "" });
   };
 
   return (
-    <FormProvider {...forgotPasswordForm}>
-      <form onSubmit={forgotPasswordForm.handleSubmit(onSubmit)}>
-        <div className="space-y-4">
-          <InputText
-            label="Email"
-            name="email"
-            placeholder="jhon@xyz.com"
-            type="email"
-          />
-        </div>
-        <div className="space-y-2 mt-8">
-          <SubmitButton title="Send Verification Link" type="submit" />
+    <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+      <div className="mb-6">
+        <h1 className="mb-2 text-title-sm font-semibold text-gray-800 dark:text-white/90 sm:text-title-md">
+          Forgot Password
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Enter your email and we will prepare a password reset link for your
+          account.
+        </p>
+      </div>
 
-          <div className="text-center">
-            <p className="block mb-2 text-sm font-medium text-gray-900">
-              Already have an account?{" "}
-              <span
-                className="text-blue cursor-pointer hover:underline"
-                onClick={onLoginClick}
-              >
-                Login
-              </span>
-            </p>
+      <FormProvider {...forgotPasswordForm}>
+        <form onSubmit={forgotPasswordForm.handleSubmit(onSubmit)}>
+          <div className="space-y-4">
+            <InputText
+              label="Email"
+              name="email"
+              placeholder="jhon@xyz.com"
+              type="email"
+            />
           </div>
-        </div>
-      </form>
-    </FormProvider>
+
+          {sentEmail && (
+            <div className="mt-5 rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-900 dark:border-emerald-500/20 dark:bg-emerald-500/10 dark:text-emerald-100">
+              If an account exists for <span className="font-medium">{sentEmail}</span>, a reset link will be sent to that inbox.
+            </div>
+          )}
+
+          <div className="space-y-3 mt-8">
+            <SubmitButton
+              title="Send Reset Link"
+              type="submit"
+              loading={isLoading}
+            />
+
+            <Link
+              href="/signin"
+              className="block text-center text-sm font-medium text-blue-700 hover:underline dark:text-blue-400"
+            >
+              Back to sign in
+            </Link>
+          </div>
+        </form>
+      </FormProvider>
+    </div>
   );
 };
 

--- a/src/components/auth/form-sign-in/SignInForm.tsx
+++ b/src/components/auth/form-sign-in/SignInForm.tsx
@@ -5,11 +5,19 @@ import InputPassword from "@/components/shared/input-password";
 import InputText from "@/components/shared/input-text";
 import SubmitButton from "@/components/shared/submit-button";
 import { useAuthContext } from "@/context";
+import { useForgotPasswordMutation } from "@/store/api/splits/auth";
+import { ForgotPasswordRequest } from "@/types/request-types";
+import { getErrorInApiResult } from "@/utils/api";
+import { useModal } from "@/hooks/useModal";
+import { Modal } from "@/components/ui/modal";
 import { zodResolver } from "@hookform/resolvers/zod";
-import Link from "next/link";
 import { useEffect, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import toast from "react-hot-toast";
+import {
+  ForgotPasswordSchema,
+  forgotPasswordSchema,
+} from "../form-forgot-password/schema";
 import { initialFormValues, LoginSchema, loginSchema } from "./schema";
 
 const ACCESS_DENIED_MESSAGE =
@@ -18,10 +26,22 @@ const ACCESS_DENIED_MESSAGE =
 export default function SignInForm() {
   const [isChecked, setIsChecked] = useState(false);
   const { login, isAuthError, setIsAuthError, isLoading } = useAuthContext();
+  const { isOpen, openModal, closeModal } = useModal();
+  const [sentEmail, setSentEmail] = useState("");
+  const [forgotPassword, { isLoading: isForgotPasswordLoading }] =
+    useForgotPasswordMutation();
 
   const loginForm = useForm<LoginSchema>({
     resolver: zodResolver(loginSchema),
     defaultValues: initialFormValues,
+    mode: "onChange",
+  });
+
+  const forgotPasswordForm = useForm<ForgotPasswordSchema>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: {
+      email: "",
+    },
     mode: "onChange",
   });
 
@@ -50,6 +70,33 @@ export default function SignInForm() {
   const onSubmit = (data: LoginSchema) => {
     setIsAuthError(null);
     login(data);
+  };
+
+  const openForgotPasswordModal = () => {
+    setSentEmail("");
+    forgotPasswordForm.reset({ email: "" });
+    openModal();
+  };
+
+  const closeForgotPasswordModal = () => {
+    setSentEmail("");
+    forgotPasswordForm.reset({ email: "" });
+    closeModal();
+  };
+
+  const handleForgotPasswordSubmit = async (data: ForgotPasswordSchema) => {
+    const payload: ForgotPasswordRequest = { email: data.email };
+    const result = await forgotPassword(payload);
+    const error = getErrorInApiResult(result);
+
+    if (error) {
+      toast.error(error);
+      return;
+    }
+
+    setSentEmail(data.email);
+    toast.success(result.data?.message ?? "Reset link request sent successfully.");
+    forgotPasswordForm.reset({ email: "" });
   };
 
   return (
@@ -88,12 +135,13 @@ export default function SignInForm() {
                     </span>
                   </div>
 
-                  <Link
-                    href="/reset-password"
+                  <button
+                    type="button"
+                    onClick={openForgotPasswordModal}
                     className="text-sm text-brand-500 hover:text-brand-600 dark:text-brand-400"
                   >
                     Forgot password?
-                  </Link>
+                  </button>
                 </div>
 
                 <SubmitButton
@@ -106,6 +154,61 @@ export default function SignInForm() {
           </FormProvider>
         </div>
       </div>
+
+      <Modal
+        isOpen={isOpen}
+        onClose={closeForgotPasswordModal}
+        className="max-w-[560px] p-0"
+        ariaLabel="Forgot password modal"
+      >
+        <div className="border-b border-gray-100 px-6 py-5 dark:border-gray-800">
+          <h2 className="text-title-sm font-semibold text-gray-800 dark:text-white/90">
+            Forgot Password
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Enter your email and we will send a reset link if the account
+            exists.
+          </p>
+        </div>
+
+        <div className="px-6 py-6">
+          <FormProvider {...forgotPasswordForm}>
+            <form onSubmit={forgotPasswordForm.handleSubmit(handleForgotPasswordSubmit)}>
+              <div className="space-y-5">
+                <InputText
+                  label="Email"
+                  name="email"
+                  placeholder="jhon@xyz.com"
+                  type="email"
+                />
+
+                {sentEmail && (
+                  <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-900 dark:border-emerald-500/20 dark:bg-emerald-500/10 dark:text-emerald-100">
+                    If an account exists for{" "}
+                    <span className="font-medium">{sentEmail}</span>, a reset
+                    link will be sent to that inbox.
+                  </div>
+                )}
+
+                <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                  <button
+                    type="button"
+                    onClick={closeForgotPasswordModal}
+                    className="rounded-lg border border-gray-300 px-5 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+                  >
+                    Cancel
+                  </button>
+                  <SubmitButton
+                    title="Send Reset Link"
+                    type="submit"
+                    loading={isForgotPasswordLoading}
+                  />
+                </div>
+              </div>
+            </form>
+          </FormProvider>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/src/store/api/endpoints.ts
+++ b/src/store/api/endpoints.ts
@@ -4,6 +4,7 @@ export const Endpoints = {
   Logout: "/v1/auth/logout",
   RefreshToken: "/v1/auth/refresh-tokens",
   ResetPassword: "/v1/auth/reset-password",
+  ForgotPassword: "/v1/auth/forgot-password",
   ContactUs: "/v1/inquiries",
   Testimonials: "/v1/testimonials",
   Faqs: "/v1/faqs",

--- a/src/store/api/splits/auth/index.ts
+++ b/src/store/api/splits/auth/index.ts
@@ -1,10 +1,12 @@
 import {
+  ForgotPasswordRequest,
   UserLoginRequest,
   UserLogoutRequest,
   UserRefreshTokenRequest,
   ResetPasswordRequest,
 } from "@/types/request-types";
 import {
+  ForgotPasswordResponse,
   TokenResponse,
   UpdatePasswordResponse,
   UserLoginResponse,
@@ -48,6 +50,13 @@ export const usersApi = baseApi.injectEndpoints({
         body: { password },
       }),
     }),
+    forgotPassword: build.mutation<ForgotPasswordResponse, ForgotPasswordRequest>({
+      query: (payload) => ({
+        url: Endpoints.ForgotPassword,
+        method: "POST",
+        body: payload,
+      }),
+    }),
   }),
 
   overrideExisting: false,
@@ -58,4 +67,5 @@ export const {
   useLogoutMutation,
   useFetchAccessTokenMutation,
   useResetPasswordMutation,
+  useForgotPasswordMutation,
 } = usersApi;

--- a/src/store/api/splits/request-tutor/index.ts
+++ b/src/store/api/splits/request-tutor/index.ts
@@ -37,10 +37,10 @@ export const RequestTutorApi = baseApi.injectEndpoints({
     }),
 
     updateStatus: build.mutation<RequestTutors, UpdateTutorRequestsRequest>({
-      query: ({ requestId, status }) => ({
+      query: ({ requestId, ...body }) => ({
         url: `${Endpoints.RequestTutor}/status/${requestId}`,
         method: "PATCH",
-        body: { status },
+        body,
       }),
       invalidatesTags: ["RequestTutor"],
     }),
@@ -56,6 +56,17 @@ export const RequestTutorApi = baseApi.injectEndpoints({
       }),
       invalidatesTags: [{ type: "RequestTutor", id: "LIST" }],
     }),
+
+    generateTutorMatchReport: build.mutation<
+      unknown,
+      { requestId: string }
+    >({
+      query: ({ requestId }) => ({
+        url: `${Endpoints.RequestTutor}/match-tutors/${requestId}`,
+        method: "POST",
+      }),
+      invalidatesTags: ["RequestTutor"],
+    }),
   }),
   overrideExisting: false,
 });
@@ -67,4 +78,5 @@ export const {
   useDeleteRequestForTutorMutation,
   useUpdateStatusMutation,
   useUpdateAssignedTutorMutation,
+  useGenerateTutorMatchReportMutation,
 } = RequestTutorApi;

--- a/src/types/request-types.ts
+++ b/src/types/request-types.ts
@@ -37,7 +37,8 @@ export type UpdateBlogStatusRequest = {
 };
 export type UpdateTutorRequestsRequest = {
   requestId: string;
-  status?: "Approved" | "Pending" | "Tutor Assigned";
+  status?: "Pending" | "Rejected";
+  rejectionReason?: string;
 };
 
 export type UserLoginRequest = {
@@ -295,26 +296,30 @@ export type FetchTutorsRequest = {
   subjectId?: string;
 };
 export type FetchRequestForTutor = {
+  search?: string;
   page?: number;
   limit?: number;
   sortBy?: string;
   requestTutorId?: string;
   name?: string;
-  medium?: string;
-  district?: string;
   email?: string;
-  grade?: string[];
-  phoneNumber?: string;
   city?: string;
-  state?: string;
+  district?: string;
+  grade?: string;
+  medium?: string;
   status?: string;
+  phoneNumber?: string;
+  subject?: string;
+  assignedTutor?: string;
+  preferredTutorType?: string;
+  preferredClassType?: string;
+  duration?: string;
+  frequency?: string;
+  state?: string;
   region?: string;
   zip?: string;
   tutors?: string[];
   subjects?: string[];
-  duration?: string;
-  frequency?: string;
-  assignedTutor?: { id: string; fullName: string }[];
 };
 export type CreateTutorRequest = {
   fullName: string;

--- a/src/types/request-types.ts
+++ b/src/types/request-types.ts
@@ -59,6 +59,10 @@ export type UserRegisterRequest = {
   name: string;
 };
 
+export type ForgotPasswordRequest = {
+  email: string;
+};
+
 export type CreateAdminRequest = {
   name: string;
   email: string;

--- a/src/types/response-types.ts
+++ b/src/types/response-types.ts
@@ -256,6 +256,10 @@ export type UpdatePasswordResponse = {
   message: string;
 };
 
+export type ForgotPasswordResponse = {
+  message: string;
+};
+
 export type TokenResponse = {
   access: {
     token: string;

--- a/src/types/response-types.ts
+++ b/src/types/response-types.ts
@@ -353,7 +353,7 @@ export type RequestTutors = BaseEntity & {
   district: string;
   phoneNumber: string;
   medium: string;
-  status: "Approved" | "Pending" | "Tutor Assigned";
+  status: "Pending" | "Rejected";
   grade: string;
   tutors: RequestTutorTutor[];
   createdAt: string;


### PR DESCRIPTION
## Summary
This PR updates the admin request-tutor feature to match the latest backend behavior and adds a new admin workflow for generating tutor match reports.

## What Changed

### Tutor request status flow
- Reduced request statuses to `Pending` and `Rejected`
- Updated the status dialog to require a rejection reason when rejecting a request
- Sent the rejection reason in the `PATCH /v1/requestTutor/status/:requestTutorId` request body
- Added stronger client-side validation so invalid reject attempts are blocked before the API call

### Tutor request listing
- Added backend-driven filtering to the request-tutor list
- Wired search and filter controls to the API query params
- Added a visible status badge beside the change-status icon in each row

### Tutor match report
- Added a new `Generate Tutor Match Report` action
- Available from the tutor request detail dialog
- Calls `POST /v1/requestTutor/match-tutors/:requestTutorId` using the authenticated admin session
- Shows loading, success, and error states
- Displays a short summary from the API response, including:
  - admin email used
  - matched tutor counts per block

## Screenshots
<img width="1917" height="938" alt="image" src="https://github.com/user-attachments/assets/755e725a-b775-4dc8-865d-203599e85511" />
<img width="1911" height="947" alt="image" src="https://github.com/user-attachments/assets/c9763239-31e1-41f1-aeac-8cac65bbdaa4" />
<img width="1912" height="940" alt="image" src="https://github.com/user-attachments/assets/5231aefa-319b-49b8-a453-1cdbd474e07e" />
