### PR TITLE
feat: use and tutor page requested changes

### DIFF
--- a/src/app/(admin)/tutors/components/ResetPassword.tsx
+++ b/src/app/(admin)/tutors/components/ResetPassword.tsx
@@ -18,36 +18,64 @@ import toast from "react-hot-toast";
 
 interface ResetPasswordProps {
   userId: string;
+  disabled?: boolean;
 }
 
-export function ResetPassword({ userId }: ResetPasswordProps) {
+export function ResetPassword({
+  userId,
+  disabled = false,
+}: ResetPasswordProps) {
   const [open, setOpen] = useState(false);
+
   const [resendPassword, { isLoading }] = useSendTempPasswordTutorMutation();
 
   const handleResend = async () => {
+    if (disabled) return;
+
     try {
-      // unwrap() throws error if mutation fails
       await resendPassword(userId).unwrap();
 
       toast.success("Temporary password sent successfully!");
-      setOpen(false); // close dialog on success
+      setOpen(false);
     } catch (error) {
-      // handle backend or network errors
-      //const message =getErrorInApiResult({ error }) || "Failed to send temporary password";
       const message = `Failed to send temporary password : ${error}`;
       toast.error(message);
     }
   };
 
   return (
-    <AlertDialog open={open} onOpenChange={setOpen}>
+    <AlertDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (disabled) return;
+        setOpen(nextOpen);
+      }}
+    >
       <AlertDialogTrigger asChild>
-        <Send className="cursor-pointer text-gray-400 hover:text-gray-500 dark:text-gray-300 dark:hover:text-white" />
+        <button
+          type="button"
+          disabled={disabled}
+          title={
+            disabled
+              ? "Password reset is only available for approved tutors"
+              : "Reset password"
+          }
+          className="disabled:cursor-not-allowed"
+        >
+          <Send
+            className={
+              disabled
+                ? "text-gray-300 dark:text-gray-600"
+                : "cursor-pointer text-gray-400 hover:text-gray-500 dark:text-gray-300 dark:hover:text-white"
+            }
+          />
+        </button>
       </AlertDialogTrigger>
 
-      <AlertDialogContent className="bg-white dark:bg-gray-800 dark:text-white/90 z-50">
+      <AlertDialogContent className="z-50 bg-white dark:bg-gray-800 dark:text-white/90">
         <AlertDialogHeader>
           <AlertDialogTitle>Send Temporary Password?</AlertDialogTitle>
+
           <AlertDialogDescription>
             This action will send a temporary password to the user via email.
             This cannot be undone.
@@ -56,10 +84,11 @@ export function ResetPassword({ userId }: ResetPasswordProps) {
 
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
+
           <AlertDialogAction
             onClick={handleResend}
-            disabled={isLoading}
-            className="bg-red-500 text-white disabled:opacity-50"
+            disabled={isLoading || disabled}
+            className="bg-red-500 text-white hover:bg-red-600 disabled:opacity-50"
           >
             {isLoading ? "Sending..." : "Resend Password"}
           </AlertDialogAction>

--- a/src/app/(admin)/tutors/components/TutorsList.tsx
+++ b/src/app/(admin)/tutors/components/TutorsList.tsx
@@ -67,8 +67,7 @@ type TutorStatusFilter =
 
 function StatusBadge({ status }: { status: string }) {
   const cls =
-    TUTOR_STATUS_BADGE_CLASSES[status] ??
-    TUTOR_STATUS_BADGE_CLASSES["pending"];
+    TUTOR_STATUS_BADGE_CLASSES[status] ?? TUTOR_STATUS_BADGE_CLASSES["pending"];
   return (
     <span
       className={`inline-block text-xs font-semibold capitalize rounded-full px-2.5 py-0.5 border ${cls}`}
@@ -130,7 +129,9 @@ function RejectDialog({
       toast.error(`Failed to reject: ${error}`);
       return;
     }
-    toast.success(`"${tutor.fullName}" has been rejected and notified by email.`);
+    toast.success(
+      `"${tutor.fullName}" has been rejected and notified by email.`,
+    );
     onClose();
   };
 
@@ -154,7 +155,9 @@ function RejectDialog({
       {/* Message */}
       <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
         Reason / Message{" "}
-        <span className="text-gray-400 font-normal">(optional — sent in the email)</span>
+        <span className="text-gray-400 font-normal">
+          (optional — sent in the email)
+        </span>
       </label>
       <textarea
         rows={4}
@@ -166,7 +169,9 @@ function RejectDialog({
                    text-sm text-gray-900 dark:text-gray-100 p-3 resize-none
                    focus:outline-none focus:ring-2 focus:ring-red-400 transition"
       />
-      <p className="text-xs text-gray-400 text-right mt-1">{message.length}/1000</p>
+      <p className="text-xs text-gray-400 text-right mt-1">
+        {message.length}/1000
+      </p>
 
       {/* Buttons */}
       <div className="flex justify-end gap-3 mt-5">
@@ -216,7 +221,9 @@ function SuspendDialog({
       toast.error(`Failed to suspend: ${error}`);
       return;
     }
-    toast.success(`"${tutor.fullName}" has been suspended and notified by email.`);
+    toast.success(
+      `"${tutor.fullName}" has been suspended and notified by email.`,
+    );
     onClose();
   };
 
@@ -239,7 +246,10 @@ function SuspendDialog({
 
       <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
         Are you sure you want to suspend{" "}
-        <strong className="text-gray-800 dark:text-gray-200">{tutor.fullName}</strong>?
+        <strong className="text-gray-800 dark:text-gray-200">
+          {tutor.fullName}
+        </strong>
+        ?
         <br />
         <span className="mt-1 block">
           They will receive an email notification and will no longer be able to
@@ -307,7 +317,9 @@ function TutorStatusActions({ tutor }: { tutor: Tutor }) {
       toast.error(`Failed to approve: ${error}`);
       return;
     }
-    toast.success(`"${tutor.fullName}" approved. Linked tutor user was created or updated.`);
+    toast.success(
+      `"${tutor.fullName}" approved. Linked tutor user was created or updated.`,
+    );
   };
 
   return (
@@ -338,7 +350,11 @@ function TutorStatusActions({ tutor }: { tutor: Tutor }) {
               stroke="currentColor"
               strokeWidth={2.5}
             >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M19 9l-7 7-7-7"
+              />
             </svg>
           )}
           Change
@@ -413,9 +429,7 @@ function TutorStatusActions({ tutor }: { tutor: Tutor }) {
   );
 }
 
-
 // ─── Main list ────────────────────────────────────────────────────────────────
-
 
 export default function TutorsList() {
   const [page, setPage] = useState<number>(TABLE_CONFIG.DEFAULT_PAGE);
@@ -451,7 +465,7 @@ export default function TutorsList() {
 
   const getSafeValue = (
     value: string | number | undefined | null,
-    fallback = "N/A"
+    fallback = "N/A",
   ) => {
     if (
       value === undefined ||
@@ -555,11 +569,24 @@ export default function TutorsList() {
         ),
         className:
           "min-w-[80px] max-w-[80px] sticky right-[80px] z-20 bg-white dark:bg-gray-900",
-        render: (row: Tutor) => (
-          <div className="flex justify-center items-center w-full">
-            <ResetPassword userId={row.id} />
-          </div>
-        ),
+        render: (row: Tutor) => {
+          const isApproved = row.status?.toLowerCase() === "approved";
+
+          return (
+            <div className="flex justify-center items-center w-full">
+              <div
+                className={!isApproved ? "cursor-not-allowed opacity-50" : ""}
+                title={
+                  !isApproved
+                    ? "Password reset is only available for approved tutors"
+                    : ""
+                }
+              >
+                <ResetPassword userId={row.id} disabled={!isApproved} />
+              </div>
+            </div>
+          );
+        },
       },
 
       // Delete button
@@ -575,7 +602,7 @@ export default function TutorsList() {
         ),
       },
     ],
-    []
+    [],
   );
 
   return (

--- a/src/app/(admin)/users/all-users/components/UserList.tsx
+++ b/src/app/(admin)/users/all-users/components/UserList.tsx
@@ -166,7 +166,8 @@ export default function UsersTable() {
     {
       key: "view",
       header: <div className="flex justify-center w-full">View</div>,
-      className: "min-w-[80px] max-w-[80px] sticky right-[260px] z-20 bg-white dark:bg-gray-900",
+      className:
+        "min-w-[80px] max-w-[80px] sticky right-[260px] z-20 bg-white dark:bg-gray-900",
       render: (row: User) => (
         <div className="w-full flex justify-center ">
           <UserDetails
@@ -193,28 +194,42 @@ export default function UsersTable() {
     {
       key: "edit",
       header: <div className="flex justify-center w-full">Edit</div>,
-      className: "min-w-[80px] max-w-[80px] sticky right-[180px] z-20 bg-white dark:bg-gray-900",
-      render: (row: User) => (
-        <div className="flex justify-center items-center w-full ">
-          <UpdateUser
-            id={row.id}
-            email={row.email || ""}
-            name={row.name || ""}
-            phoneNumber={row.phoneNumber || ""}
-            birthday={row.birthday || ""}
-            status={row.status || "pending"}
-            country={row.country || ""}
-            city={row.city || ""}
-            zip={row.zip || ""}
-            address={row.address || ""}
-            state={row.state}
-            region={row.region}
-            gender={row.gender}
-            avatar={row.avatar}
-            role={row.role === "admin" ? "admin" : "tutor"}
-          />
-        </div>
-      ),
+      className:
+        "min-w-[80px] max-w-[80px] sticky right-[180px] z-20 bg-white dark:bg-gray-900",
+      render: (row: User) => {
+        const isTutor = row.role === "tutor";
+
+        return (
+          <div className="flex justify-center items-center w-full">
+            {isTutor ? (
+              <span
+                title="Tutor details can be edited from the Tutor page"
+                className="cursor-not-allowed text-gray-300 dark:text-gray-600"
+              >
+                Disabled
+              </span>
+            ) : (
+              <UpdateUser
+                id={row.id}
+                email={row.email || ""}
+                name={row.name || ""}
+                phoneNumber={row.phoneNumber || ""}
+                birthday={row.birthday || ""}
+                status={row.status || "pending"}
+                country={row.country || ""}
+                city={row.city || ""}
+                zip={row.zip || ""}
+                address={row.address || ""}
+                state={row.state}
+                region={row.region}
+                gender={row.gender}
+                avatar={row.avatar}
+                role="admin"
+              />
+            )}
+          </div>
+        );
+      },
     },
     {
       key: "resetPassword",
@@ -226,7 +241,8 @@ export default function UsersTable() {
           Reset Password
         </span>
       ),
-      className: "min-w-[80px] max-w-[100px] sticky right-[80px] z-20 bg-white dark:bg-gray-900",
+      className:
+        "min-w-[80px] max-w-[100px] sticky right-[80px] z-20 bg-white dark:bg-gray-900",
       render: (row: User) => (
         <div className="w-full flex justify-center">
           <ResetPassword userId={row.id} />
@@ -236,7 +252,8 @@ export default function UsersTable() {
     {
       key: "delete",
       header: <div className="text-center w-full">Delete</div>,
-      className: "min-w-[80px] max-w-[80px] flex justify-center sticky right-0 z-20 bg-white dark:bg-gray-900",
+      className:
+        "min-w-[80px] max-w-[80px] flex justify-center sticky right-0 z-20 bg-white dark:bg-gray-900",
       render: (row: User) => (
         <div className="flex justify-center  w-full ">
           <DeleteUser userId={row.id} userStatus={row.status ?? "pending"} />

--- a/src/app/(admin)/users/all-users/components/page.tsx
+++ b/src/app/(admin)/users/all-users/components/page.tsx
@@ -1,4 +1,3 @@
-import AddUser from "./add-user/AddUser";
 import SubjectsTable from "./UserList";
 
 export default function Profile() {
@@ -9,7 +8,6 @@ export default function Profile() {
           <h3 className="text-xl sm:text-2xl md:text-3xl lg:text-4xl font-semibold text-gray-800 dark:text-white/90">
             Users
           </h3>
-          <AddUser />
         </div>
 
         <div className="space-y-6">


### PR DESCRIPTION
# Changes Made

## Tutor Page

### Reset Password Restriction
- Enabled the **Reset Password** action only for tutors with `approved` status
- Disabled the reset password option for:
  - Pending tutors
  - Rejected tutors
  - Suspended tutors

### Disabled State Improvements
- Added visual disabled styles for unavailable reset actions
- Added tooltip message:
  - `"Password reset is only available for approved tutors"`

### ResetPassword Component Improvements
- Added optional `disabled` prop support
- Prevented dialog opening when disabled
- Prevented resend action execution when disabled

## User Page

### Disable Tutor Edit Option
- Disabled the edit option for users with `tutor` role
- Only `admin` users can now be edited from the Users page

### Removing the Add User Button

## Screenshots
<img width="1916" height="947" alt="image" src="https://github.com/user-attachments/assets/b2380d5b-6819-4ee4-8581-1b26d9bd305f" />

