### PR TITLE
fix: resolve dialog header overlaps (TM-856–861) and tutor form validation issues (TM-869)

### DIFF
--- a/src/app/(admin)/blogs/blogs/ViewDetails.tsx
+++ b/src/app/(admin)/blogs/blogs/ViewDetails.tsx
@@ -90,12 +90,12 @@ export function BlogDetails({ blog }: BlogDetailsProps) {
         <Eye cursor="pointer" className="text-blue-500 hover:text-blue-700" />
       </DialogTrigger>
 
-      <DialogContent className="sm:max-w-[600px] max-h-[75vh] overflow-y-auto scrollbar-thin bg-white z-[50] dark:bg-gray-800 dark:text-white/90">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[600px] max-h-[75vh] overflow-hidden bg-white z-50 dark:bg-gray-800 dark:text-white/90 p-0 [&>div:last-child]:flex [&>div:last-child]:min-h-0 [&>div:last-child]:flex-col [&>div:last-child]:overflow-hidden [&>div:last-child]:p-0">
+        <DialogHeader className="shrink-0 px-6 py-4 border-b bg-white dark:bg-gray-800">
           <DialogTitle className="text-2xl font-bold">{blog.title}</DialogTitle>
         </DialogHeader>
 
-        <div className="mt-4 space-y-6">
+        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin px-6 py-4 space-y-6">
           {blog.image && (
             <div>
               <img

--- a/src/app/(admin)/faqs/components/FAQDetails.tsx
+++ b/src/app/(admin)/faqs/components/FAQDetails.tsx
@@ -47,12 +47,12 @@ export function FAQDetails({
       <DialogTrigger asChild>
         <Eye className="cursor-pointer text-blue-500 hover:text-blue-700" />
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px] max-h-[75vh] scrollbar-thin overflow-y-auto bg-white z-50 dark:bg-gray-800 dark:text-white/90">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[525px] max-h-[75vh] overflow-hidden bg-white z-50 dark:bg-gray-800 dark:text-white/90 p-0 [&>div:last-child]:flex [&>div:last-child]:min-h-0 [&>div:last-child]:flex-col [&>div:last-child]:overflow-hidden [&>div:last-child]:p-0">
+        <DialogHeader className="shrink-0 px-6 py-4 border-b bg-white dark:bg-gray-800">
           <DialogTitle>Details</DialogTitle>
           <DialogDescription>FAQ Details</DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4">
+        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin px-6 py-4 grid gap-4">
           <div className="grid gap-3">
             <Label>ID</Label>
             <div

--- a/src/app/(admin)/grades/ViewDetails.tsx
+++ b/src/app/(admin)/grades/ViewDetails.tsx
@@ -38,15 +38,15 @@ export function GradeDetails({
       <DialogTrigger asChild>
         <Eye cursor="pointer " className="text-blue-500 hover:text-blue-700" />
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[425px] max-h-[75vh] overflow-y-auto bg-white z-[50] dark:bg-gray-800 dark:text-white/90">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[425px] max-h-[75vh] overflow-hidden bg-white z-50 dark:bg-gray-800 dark:text-white/90 p-0 [&>div:last-child]:flex [&>div:last-child]:min-h-0 [&>div:last-child]:flex-col [&>div:last-child]:overflow-hidden [&>div:last-child]:p-0">
+        <DialogHeader className="shrink-0 px-6 py-4 border-b bg-white dark:bg-gray-800">
           <DialogTitle>Grade Details</DialogTitle>
           <DialogDescription>
             View the title, description, and subjects of this grade.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="grid gap-4">
+        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin px-6 py-4 grid gap-4">
           {/* Title */}
           <div className="grid gap-3">
             <Label>Title</Label>
@@ -56,7 +56,7 @@ export function GradeDetails({
           {/* Description */}
           <div className="grid gap-3">
             <Label>Description</Label>
-            <div className={`${displayFieldClass} min-h-[5rem] overflow-auto`}>
+            <div className={`${displayFieldClass} min-h-20 overflow-auto`}>
               {description}
             </div>
           </div>

--- a/src/app/(admin)/grades/edit-grade/UpdateGrade.tsx
+++ b/src/app/(admin)/grades/edit-grade/UpdateGrade.tsx
@@ -120,14 +120,14 @@ export function UpdateGrade({
         <SquarePen className="cursor-pointer text-blue-500 hover:text-blue-700" />
       </DialogTrigger>
 
-      <DialogContent className="sm:max-w-[425px] bg-white z-[9999] dark:bg-gray-800 dark:text-white/90">
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <DialogHeader>
+      <DialogContent className="sm:max-w-[425px] bg-white z-9999 dark:bg-gray-800 dark:text-white/90 p-0 overflow-hidden [&>div:last-child]:flex [&>div:last-child]:min-h-0 [&>div:last-child]:flex-col [&>div:last-child]:overflow-hidden [&>div:last-child]:p-0">
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0 overflow-hidden">
+          <DialogHeader className="shrink-0 px-6 py-4 border-b bg-white dark:bg-gray-800">
             <DialogTitle>Edit Grade</DialogTitle>
             <DialogDescription>Edit the grade details.</DialogDescription>
           </DialogHeader>
 
-          <div className="grid gap-4">
+          <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin px-6 py-4 grid gap-4">
             <div className="grid gap-3">
               <Label htmlFor="title">Title</Label>
               <Input id="title" placeholder="Title" {...register("title")} />
@@ -172,7 +172,7 @@ export function UpdateGrade({
             </div>
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="shrink-0 px-6 py-4 border-t bg-white dark:bg-gray-800">
             <DialogClose asChild>
               <Button variant="outline">Cancel</Button>
             </DialogClose>

--- a/src/app/(admin)/inquiries/contactus/components/ViewInquiries.tsx
+++ b/src/app/(admin)/inquiries/contactus/components/ViewInquiries.tsx
@@ -59,12 +59,12 @@ export function InquiryDetails({
       <DialogTrigger asChild>
         <Eye className="cursor-pointer" />
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px] max-h-[75vh] scrollbar-thin overflow-y-auto bg-white z-50 dark:bg-gray-800 dark:text-white/90">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[525px] max-h-[75vh] overflow-hidden bg-white z-50 dark:bg-gray-800 dark:text-white/90 p-0 [&>div:last-child]:flex [&>div:last-child]:min-h-0 [&>div:last-child]:flex-col [&>div:last-child]:overflow-hidden [&>div:last-child]:p-0">
+        <DialogHeader className="shrink-0 px-6 py-4 border-b bg-white dark:bg-gray-800">
           <DialogTitle>Details</DialogTitle>
           <DialogDescription>Inquiry Details</DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4">
+        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin px-6 py-4 grid gap-4">
           <div className="grid gap-3">
             <Label>ID</Label>
             <div

--- a/src/app/(admin)/inquiries/contactus/components/add-inquiry/AddInquiry.tsx
+++ b/src/app/(admin)/inquiries/contactus/components/add-inquiry/AddInquiry.tsx
@@ -82,16 +82,16 @@ export function AddInquiry() {
         </Button>
       </DialogTrigger>
 
-      <DialogContent className="sm:max-w-[425px] bg-white z-50 dark:bg-gray-800 dark:text-white/90">
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <DialogHeader>
+      <DialogContent className="sm:max-w-[425px] bg-white z-50 dark:bg-gray-800 dark:text-white/90 p-0 overflow-hidden [&>div:last-child]:flex [&>div:last-child]:min-h-0 [&>div:last-child]:flex-col [&>div:last-child]:overflow-hidden [&>div:last-child]:p-0">
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0 overflow-hidden">
+          <DialogHeader className="shrink-0 px-6 py-4 border-b bg-white dark:bg-gray-800">
             <DialogTitle>Add Inquiry (Manually)</DialogTitle>
-            <DialogDescription className="mb-2 ">
+            <DialogDescription>
               Add a new inquiry with sender name, email, and inquiry.
             </DialogDescription>
           </DialogHeader>
 
-          <div className="grid gap-4">
+          <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin px-6 py-4 grid gap-4">
             {/* Sender Name */}
             <div className="grid gap-3">
               <Label htmlFor="senderName">Sender Name</Label>
@@ -145,7 +145,7 @@ export function AddInquiry() {
             </div>
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="shrink-0 px-6 py-4 border-t bg-white dark:bg-gray-800">
             <DialogClose asChild>
               <Button variant="outline">Cancel</Button>
             </DialogClose>

--- a/src/app/(admin)/papers/components/ViewDetails.tsx
+++ b/src/app/(admin)/papers/components/ViewDetails.tsx
@@ -41,13 +41,13 @@ export function PaperDetails({
         <Eye cursor="pointer" className="text-blue-500 hover:text-blue-700" />
       </DialogTrigger>
 
-      <DialogContent className="w-[95vw] max-w-[500px] max-h-[80vh] overflow-x-hidden overflow-y-auto scrollbar-thin bg-white z-50 dark:bg-gray-800 dark:text-white/90">
-        <DialogHeader>
+      <DialogContent className="w-[95vw] max-w-[500px] max-h-[80vh] overflow-hidden bg-white z-50 dark:bg-gray-800 dark:text-white/90 p-0 [&>div:last-child]:flex [&>div:last-child]:min-h-0 [&>div:last-child]:flex-col [&>div:last-child]:overflow-hidden [&>div:last-child]:p-0">
+        <DialogHeader className="shrink-0 px-6 py-4 border-b bg-white dark:bg-gray-800">
           <DialogTitle>Paper Details</DialogTitle>
           <DialogDescription>Information about this paper</DialogDescription>
         </DialogHeader>
 
-        <div className="grid min-w-0 gap-4">
+        <div className="flex-1 min-h-0 overflow-x-hidden overflow-y-auto scrollbar-thin px-6 py-4 grid min-w-0 gap-4">
           <div className="grid min-w-0 gap-3">
             <Label>Title</Label>
             <div className={cn(displayFieldClass)}>{title}</div>

--- a/src/app/(admin)/papers/components/add-paper/AddPaper.tsx
+++ b/src/app/(admin)/papers/components/add-paper/AddPaper.tsx
@@ -136,13 +136,13 @@ export function AddPaper() {
           </Button>
         </DialogTrigger>
 
-        <DialogContent className="sm:max-w-[425px] bg-white z-50 dark:bg-gray-800 dark:text-white/90">
-          <DialogHeader>
+        <DialogContent className="sm:max-w-[425px] bg-white z-50 dark:bg-gray-800 dark:text-white/90 p-0 overflow-hidden [&>div:last-child]:flex [&>div:last-child]:min-h-0 [&>div:last-child]:flex-col [&>div:last-child]:overflow-hidden [&>div:last-child]:p-0">
+          <DialogHeader className="shrink-0 px-6 py-4 border-b bg-white dark:bg-gray-800">
             <DialogTitle>Add Paper</DialogTitle>
             <DialogDescription>Add a new paper to the list.</DialogDescription>
           </DialogHeader>
 
-          <div className="grid gap-4 max-h-[67vh] overflow-y-auto">
+          <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin px-6 py-4 grid gap-4">
             <div className="grid gap-3">
               <Label htmlFor="title">Title</Label>
               <Input id="title" placeholder="Title" {...register("title")} />
@@ -343,7 +343,7 @@ export function AddPaper() {
             </div>
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="shrink-0 px-6 py-4 border-t bg-white dark:bg-gray-800">
             <DialogClose asChild>
               <Button variant="outline">Cancel</Button>
             </DialogClose>

--- a/src/app/(admin)/papers/components/edit-paper/EditPaper.tsx
+++ b/src/app/(admin)/papers/components/edit-paper/EditPaper.tsx
@@ -201,17 +201,17 @@ export function EditPaper({
         <SquarePen className="cursor-pointer text-blue-500 hover:text-blue-700" />
       </DialogTrigger>
 
-      <DialogContent className="w-[95vw] max-w-[425px] max-h-[85vh] overflow-x-hidden bg-white z-50 dark:bg-gray-800 dark:text-white/90">
+      <DialogContent className="w-[95vw] max-w-[425px] max-h-[85vh] overflow-hidden bg-white z-50 dark:bg-gray-800 dark:text-white/90 p-0 [&>div:last-child]:flex [&>div:last-child]:min-h-0 [&>div:last-child]:flex-col [&>div:last-child]:overflow-hidden [&>div:last-child]:p-0">
         <form
           onSubmit={updatePaperForm.handleSubmit(onSubmit)}
-          className="min-w-0"
+          className="flex flex-col flex-1 min-h-0 overflow-hidden min-w-0"
         >
-          <DialogHeader>
+          <DialogHeader className="shrink-0 px-6 py-4 border-b bg-white dark:bg-gray-800">
             <DialogTitle>Edit Paper</DialogTitle>
             <DialogDescription>Edit the paper details.</DialogDescription>
           </DialogHeader>
 
-          <div className="grid min-w-0 gap-4 max-h-[67vh] overflow-x-hidden overflow-y-auto pr-1">
+          <div className="flex-1 min-h-0 overflow-x-hidden overflow-y-auto scrollbar-thin px-6 py-4 grid min-w-0 gap-4">
             <div className="grid min-w-0 gap-3">
               <Label>Title</Label>
               <Input {...register("title")} className="w-full min-w-0" />
@@ -416,7 +416,7 @@ export function EditPaper({
             </div>
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="shrink-0 px-6 py-4 border-t bg-white dark:bg-gray-800">
             <DialogClose asChild>
               <Button variant="outline" onClick={handleCancel}>
                 Cancel

--- a/src/app/(admin)/testimonials/components/add-testimonial/AddTestimonial.tsx
+++ b/src/app/(admin)/testimonials/components/add-testimonial/AddTestimonial.tsx
@@ -93,15 +93,15 @@ export function AddTestimonial() {
           </Button>
         </DialogTrigger>
 
-        <DialogContent className="z-50 bg-white dark:bg-gray-800 dark:text-white/90 sm:max-w-[425px]">
-          <DialogHeader>
+        <DialogContent className="z-50 bg-white dark:bg-gray-800 dark:text-white/90 sm:max-w-[425px] p-0 overflow-hidden [&>div:last-child]:flex [&>div:last-child]:min-h-0 [&>div:last-child]:flex-col [&>div:last-child]:overflow-hidden [&>div:last-child]:p-0">
+          <DialogHeader className="shrink-0 px-6 py-4 border-b bg-white dark:bg-gray-800">
             <DialogTitle>Add Testimonial</DialogTitle>
             <DialogDescription>
               Fill in the details to create a new testimonial.
             </DialogDescription>
           </DialogHeader>
 
-          <div className="grid gap-4">
+          <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin px-6 py-4 grid gap-4">
             <div className="grid gap-3">
               <Label htmlFor="content">Content</Label>
               <Input
@@ -189,7 +189,7 @@ export function AddTestimonial() {
             </div>
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="shrink-0 px-6 py-4 border-t bg-white dark:bg-gray-800">
             <DialogClose asChild>
               <Button variant="outline">Cancel</Button>
             </DialogClose>

--- a/src/app/(admin)/testimonials/components/edit-testimonial/UpdateTestimonial.tsx
+++ b/src/app/(admin)/testimonials/components/edit-testimonial/UpdateTestimonial.tsx
@@ -23,7 +23,6 @@ import { useUpdateTestimonialMutation } from "@/store/api/splits/testimonials";
 import { getErrorInApiResult } from "@/utils/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { SquarePen } from "lucide-react";
-import Image from "next/image";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import toast from "react-hot-toast";
@@ -112,13 +111,13 @@ export function UpdateTestimonial({
           <SquarePen className="cursor-pointer text-blue-500 hover:text-blue-700" />
         </DialogTrigger>
 
-        <DialogContent className="z-50 bg-white dark:bg-gray-800 dark:text-white/90 sm:max-w-[425px]">
-          <DialogHeader>
+        <DialogContent className="z-50 bg-white dark:bg-gray-800 dark:text-white/90 sm:max-w-[425px] p-0 overflow-hidden [&>div:last-child]:flex [&>div:last-child]:min-h-0 [&>div:last-child]:flex-col [&>div:last-child]:overflow-hidden [&>div:last-child]:p-0">
+          <DialogHeader className="shrink-0 px-6 py-4 border-b bg-white dark:bg-gray-800">
             <DialogTitle>Edit Testimonial</DialogTitle>
             <DialogDescription>Edit the testimonial details.</DialogDescription>
           </DialogHeader>
 
-          <div className="grid gap-4">
+          <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin px-6 py-4 grid gap-4">
             {/* Content */}
             <div className="grid gap-3">
               <Label htmlFor="content">Content</Label>
@@ -198,7 +197,8 @@ export function UpdateTestimonial({
               />
 
               {avatarUrl && (
-                <Image
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
                   src={avatarUrl}
                   alt="Avatar preview"
                   width={64}
@@ -215,7 +215,7 @@ export function UpdateTestimonial({
             </div>
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="shrink-0 px-6 py-4 border-t bg-white dark:bg-gray-800">
             <DialogClose asChild>
               <Button variant="outline">Cancel</Button>
             </DialogClose>

--- a/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
+++ b/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
@@ -214,7 +214,8 @@ export function AddTutor() {
     if (age < 0) age = 0;
 
     setValue("age", age, { shouldValidate: true });
-  }, [dob, setValue]);
+    form.trigger("age");
+  }, [dob, form, setValue]);
 
   const handleYearsSelect = (val: string) => {
     const parsed = val === "10+" ? 10 : parseInt(val || "0", 10);

--- a/src/app/(admin)/tutors/components/add-tutor/schema.ts
+++ b/src/app/(admin)/tutors/components/add-tutor/schema.ts
@@ -38,12 +38,12 @@ export const addTutorSchema = z.object({
         .regex(/^\d{4}-\d{2}-\d{2}$/, "Date of Birth must be in YYYY-MM-DD"),
     ),
 
-  gender: z.enum(TUTOR_GENDER_VALUES),
+  gender: z.enum(TUTOR_GENDER_VALUES, { message: "Gender is required" }),
   age: z
     .number()
     .int()
     .min(18, "Must be at least 18 years old")
-    .max(80, "Must be 80 or under"),
+    .max(80, "Age must be below 80"),
 
   tutorMediums: z
     .array(z.string())
@@ -51,8 +51,8 @@ export const addTutorSchema = z.object({
 
   grades: z.array(z.string()).min(1, "Select at least one grade"),
   subjects: z.array(z.string()).min(1, "Select at least one subject"),
-  nationality: z.enum(NATIONALITY_VALUES),
-  race: z.enum(RACE_VALUES),
+  nationality: z.enum(NATIONALITY_VALUES, { message: "Nationality is required" }),
+  race: z.enum(RACE_VALUES, { message: "Race is required" }),
 
   classType: z
     .array(z.enum(CLASS_TYPE_VALUES))
@@ -68,7 +68,7 @@ export const addTutorSchema = z.object({
 
   yearsExperience: z.number().int().min(1, "Years of Experience are required").max(50),
 
-  highestEducation: z.enum(EDUCATION_VALUES_ADD),
+  highestEducation: z.enum(EDUCATION_VALUES_ADD, { message: "Highest Education is required" }),
 
   academicDetails: z.string().min(1, "Academic Details are required").max(1000),
   teachingSummary: z.string().min(1, "Teaching Summary is required").max(750),

--- a/src/app/(admin)/tutors/components/edit-tutor/EditTutor.tsx
+++ b/src/app/(admin)/tutors/components/edit-tutor/EditTutor.tsx
@@ -357,7 +357,8 @@ export function EditTutor({ id }: EditTutorProps) {
       shouldDirty: true,
       shouldValidate: true,
     });
-  }, [dob, setValue]);
+    form.trigger("age");
+  }, [dob, form, setValue]);
 
   const handleYearsSelect = (val: string) => {
     const parsed = val === "10+" ? 10 : parseInt(val || "0", 10);

--- a/src/app/(admin)/tutors/components/edit-tutor/schema.ts
+++ b/src/app/(admin)/tutors/components/edit-tutor/schema.ts
@@ -56,7 +56,7 @@ export const updateTutorSchema = z.object({
     )
     .optional(),
   gender: z.enum(TUTOR_GENDER_VALUES).optional(),
-  age: z.number().int().min(18, "Must be at least 18 years old").optional(),
+  age: z.number().int().min(18, "Must be at least 18 years old").max(80, "Age must be below 80").optional(),
   tutorMediums: z.array(z.string()).optional(),
   grades: z.array(z.string()).optional(),
   subjects: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

- **TM-856 to TM-861** — Fixed dialog header/footer overlap with scrollable content across 
  Blogs, Testimonials, FAQs, Inquiries, Grades, and Papers views/forms. Root cause was 
  shadcn/ui `DialogContent`'s inner wrapper div consuming full height — fixed by converting 
  it to a flex column layout with `shrink-0` headers/footers and `flex-1 overflow-y-auto` 
  content areas.
- **TM-857 (additional)** — Fixed `next/image` crash on Edit Testimonial when avatar URL is 
  from an unconfigured external hostname (unsplash.com). Replaced with plain `<img>` tag.
- **TM-869** — Fixed missing age validation message (>80) in Add Tutor and Edit Tutor forms. 
  Added `.max(80)` constraint to edit tutor schema and added `form.trigger("age")` to ensure 
  revalidation fires when date of birth changes.
- **Zod v4 compatibility** — Fixed Add Tutor form showing raw Zod enum error messages 
  (`Invalid option: expected one of 'Male'|'Female'`) instead of friendly messages. Updated 
  `z.enum()` calls to use `{ message: "..." }` syntax required by Zod v4.

## Test plan

- [ ] Open each dialog (Blog view, Testimonials add/edit, FAQ details, Inquiry view/add, 
      Grade view/edit, Papers view/add/edit) — header and footer should stay fixed while 
      content scrolls
- [ ] Edit a testimonial with an external avatar image — no crash
- [ ] Add Tutor: submit without filling Gender/Nationality/Race/Education — friendly messages 
      should appear, not raw Zod enum errors
- [ ] Add Tutor: enter DOB that gives age > 80 — "Age must be below 80" message should appear
- [ ] Edit Tutor: same age > 80 test