### PR TITLE
Fix admin tutor form validation and status UI issues

### DIFF
--- a/src/app/(admin)/(others-pages)/profile/components/UserMetaCard.tsx
+++ b/src/app/(admin)/(others-pages)/profile/components/UserMetaCard.tsx
@@ -30,6 +30,19 @@ export default function UserMetaCard() {
 
   const avatarSrc =
     isImageError || !user.avatar ? "/images/user/user.png" : user.avatar;
+  const status = user.status?.toLowerCase();
+  const statusBadgeClass =
+    status === "approved"
+      ? "bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100"
+      : status === "pending"
+        ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100"
+        : "bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100";
+  const statusDotClass =
+    status === "approved"
+      ? "bg-green-500"
+      : status === "pending"
+        ? "bg-yellow-500"
+        : "bg-red-500";
 
   return (
     <div className="p-5 border border-gray-200 rounded-2xl dark:border-gray-800 lg:p-6">
@@ -51,16 +64,11 @@ export default function UserMetaCard() {
               <div
                 className={cn(
                   "flex items-center gap-2 px-3 py-1 rounded-full text-sm font-medium",
-                  user.status === "approved"
-                    ? "bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100"
-                    : "bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100",
+                  statusBadgeClass,
                 )}
               >
                 <span
-                  className={cn(
-                    "h-2 w-2 rounded-full",
-                    user.status === "approved" ? "bg-green-500" : "bg-red-500",
-                  )}
+                  className={cn("h-2 w-2 rounded-full", statusDotClass)}
                 ></span>
                 <span>
                   {user.status.charAt(0).toUpperCase() + user.status.slice(1)}

--- a/src/app/(admin)/(others-pages)/profile/components/UserMetaCard.tsx
+++ b/src/app/(admin)/(others-pages)/profile/components/UserMetaCard.tsx
@@ -51,7 +51,7 @@ export default function UserMetaCard() {
               <div
                 className={cn(
                   "flex items-center gap-2 px-3 py-1 rounded-full text-sm font-medium",
-                  user.status === "active"
+                  user.status === "approved"
                     ? "bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100"
                     : "bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100",
                 )}
@@ -59,7 +59,7 @@ export default function UserMetaCard() {
                 <span
                   className={cn(
                     "h-2 w-2 rounded-full",
-                    user.status === "active" ? "bg-green-500" : "bg-red-500",
+                    user.status === "approved" ? "bg-green-500" : "bg-red-500",
                   )}
                 ></span>
                 <span>

--- a/src/app/(admin)/(others-pages)/profile/components/UserMetaCard.tsx
+++ b/src/app/(admin)/(others-pages)/profile/components/UserMetaCard.tsx
@@ -31,18 +31,35 @@ export default function UserMetaCard() {
   const avatarSrc =
     isImageError || !user.avatar ? "/images/user/user.png" : user.avatar;
   const status = user.status?.toLowerCase();
-  const statusBadgeClass =
-    status === "approved"
-      ? "bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100"
+  const statusStyles =
+    status === "approved" || status === "active"
+      ? {
+          badge: "bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100",
+          dot: "bg-green-500",
+        }
       : status === "pending"
-        ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100"
-        : "bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100";
-  const statusDotClass =
-    status === "approved"
-      ? "bg-green-500"
-      : status === "pending"
-        ? "bg-yellow-500"
-        : "bg-red-500";
+        ? {
+            badge:
+              "bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100",
+            dot: "bg-yellow-500",
+          }
+        : status === "suspended"
+          ? {
+              badge:
+                "bg-orange-100 text-orange-800 dark:bg-orange-900/60 dark:text-orange-100",
+              dot: "bg-orange-500",
+            }
+          : status === "rejected"
+            ? {
+                badge:
+                  "bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100",
+                dot: "bg-red-500",
+              }
+            : {
+                badge:
+                  "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200",
+                dot: "bg-gray-500",
+              };
 
   return (
     <div className="p-5 border border-gray-200 rounded-2xl dark:border-gray-800 lg:p-6">
@@ -64,11 +81,11 @@ export default function UserMetaCard() {
               <div
                 className={cn(
                   "flex items-center gap-2 px-3 py-1 rounded-full text-sm font-medium",
-                  statusBadgeClass,
+                  statusStyles.badge,
                 )}
               >
                 <span
-                  className={cn("h-2 w-2 rounded-full", statusDotClass)}
+                  className={cn("h-2 w-2 rounded-full", statusStyles.dot)}
                 ></span>
                 <span>
                   {user.status.charAt(0).toUpperCase() + user.status.slice(1)}

--- a/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
+++ b/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
@@ -729,6 +729,7 @@ export function AddTutor() {
                     )
                   }
                   options={[...EDUCATION_OPTIONS_ADD]}
+                  placeholder="Select highest education"
                 />
               </div>
 

--- a/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
+++ b/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
 import {
   Select,
   SelectContent,
@@ -38,15 +39,19 @@ import {
   useFetchGradesQuery,
   useLazyFetchGradeByIdQuery,
 } from "@/store/api/splits/grades";
-import { useCreateTutorMutation } from "@/store/api/splits/tutors";
+import {
+  useCreateTutorMutation,
+  useLazyGetTutorEmailAvailabilityQuery,
+} from "@/store/api/splits/tutors";
 import { getErrorInApiResult } from "@/utils/api";
 import {
   collapseTextSpaces,
   normalizeTextSpaces,
+  removeWhitespace,
   stripLeadingSpaces,
 } from "@/utils/form-normalizers";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Eye, EyeOff } from "lucide-react";
+import { CircleCheck, CircleX, Eye, EyeOff } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import {
   Controller,
@@ -68,11 +73,32 @@ const getMinimumAdultBirthDate = () => {
   return new Date(today.getFullYear() - 18, today.getMonth(), today.getDate());
 };
 
+const EMAIL_CHECK_DELAY_MS = 500;
+const DUPLICATE_EMAIL_MESSAGE = "Email already exists";
+const EMAIL_FORMAT_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const isDuplicateEmailError = (error: string) => {
+  const normalizedError = error.toLowerCase();
+
+  return (
+    normalizedError.includes("email") &&
+    (normalizedError.includes("already exists") ||
+      normalizedError.includes("already in use") ||
+      normalizedError.includes("already taken"))
+  );
+};
+
+type EmailAvailabilityState = "available" | "unavailable" | null;
+
 export function AddTutor() {
   const [open, setOpen] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [emailAvailability, setEmailAvailability] =
+    useState<EmailAvailabilityState>(null);
   const [createTutor, { isLoading }] = useCreateTutorMutation();
+  const [checkTutorEmailAvailability, { isFetching: isCheckingEmail }] =
+    useLazyGetTutorEmailAvailabilityQuery();
   const formId = "add-tutor-form";
   const maxTutorDateOfBirth = getMinimumAdultBirthDate();
 
@@ -82,7 +108,16 @@ export function AddTutor() {
     mode: "onChange",
   });
 
-  const { formState, reset, setValue, watch, control } = form;
+  const {
+    clearErrors,
+    control,
+    formState,
+    reset,
+    setError,
+    setFocus,
+    setValue,
+    watch,
+  } = form;
 
   const selectedGrades = useWatch({
     control,
@@ -102,6 +137,12 @@ export function AddTutor() {
     defaultValue: "",
   }) as string;
 
+  const email = useWatch({
+    control,
+    name: "email",
+    defaultValue: "",
+  }) as string;
+
   const { data: gradesData } = useFetchGradesQuery({ page: 1, limit: 100 });
   const [fetchGradeById] = useLazyFetchGradeByIdQuery();
 
@@ -113,6 +154,7 @@ export function AddTutor() {
   >([]);
 
   const prevUniqueSubjectsRef = useRef<string | null>(null);
+  const latestEmailRef = useRef("");
   const selectedGradesJson = JSON.stringify(selectedGrades || []);
 
   useEffect(() => {
@@ -191,6 +233,7 @@ export function AddTutor() {
       reset(initialTutorFormValues);
       setShowPassword(false);
       setShowConfirmPassword(false);
+      setEmailAvailability(null);
     }
   }, [open, reset]);
 
@@ -201,8 +244,49 @@ export function AddTutor() {
       reset(initialTutorFormValues);
       setShowPassword(false);
       setShowConfirmPassword(false);
+      setEmailAvailability(null);
     }
   };
+
+  useEffect(() => {
+    const normalizedEmail =
+      typeof email === "string" ? removeWhitespace(email).toLowerCase() : "";
+
+    latestEmailRef.current = normalizedEmail;
+
+    if (!open || !normalizedEmail || !EMAIL_FORMAT_PATTERN.test(normalizedEmail)) {
+      setEmailAvailability(null);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(async () => {
+      const result = await checkTutorEmailAvailability(normalizedEmail, true);
+
+      if (latestEmailRef.current !== normalizedEmail) return;
+
+      if (!result.data) return;
+
+      if (!result.data.available) {
+        setEmailAvailability("unavailable");
+        setError("email", {
+          type: "server",
+          message: result.data.message || DUPLICATE_EMAIL_MESSAGE,
+        });
+        return;
+      }
+
+      setEmailAvailability("available");
+      clearErrors("email");
+    }, EMAIL_CHECK_DELAY_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [
+    checkTutorEmailAvailability,
+    clearErrors,
+    email,
+    open,
+    setError,
+  ]);
 
   useEffect(() => {
     if (!dob) return;
@@ -233,9 +317,29 @@ export function AddTutor() {
   };
 
   const onSubmit = async (data: AddTutorFormValues) => {
+    const normalizedEmail = removeWhitespace(data.email).toLowerCase();
+    setValue("email", normalizedEmail, { shouldValidate: true });
+
+    const emailAvailabilityResult =
+      await checkTutorEmailAvailability(normalizedEmail);
+
+    if (
+      emailAvailabilityResult.data &&
+      !emailAvailabilityResult.data.available
+    ) {
+      setEmailAvailability("unavailable");
+      setError("email", {
+        type: "server",
+        message: emailAvailabilityResult.data.message || DUPLICATE_EMAIL_MESSAGE,
+      });
+      setFocus("email");
+      return;
+    }
+
     const { confirmPassword: _, ...rest } = data;
     const cleanedData = {
       ...rest,
+      email: normalizedEmail,
       fullName: normalizeTextSpaces(data.fullName) as string,
       academicDetails: normalizeTextSpaces(
         data.academicDetails || "",
@@ -250,6 +354,15 @@ export function AddTutor() {
     const error = getErrorInApiResult(result);
 
     if (error) {
+      if (isDuplicateEmailError(error)) {
+        setError("email", {
+          type: "server",
+          message: DUPLICATE_EMAIL_MESSAGE,
+        });
+        setFocus("email");
+        return;
+      }
+
       toast.error(error);
       return;
     }
@@ -258,6 +371,7 @@ export function AddTutor() {
       reset(initialTutorFormValues);
       setShowPassword(false);
       setShowConfirmPassword(false);
+      setEmailAvailability(null);
       toast.success("Tutor added successfully");
       setOpen(false);
     }
@@ -283,7 +397,15 @@ export function AddTutor() {
 
   const emailRegister = form.register("email", {
     onChange: (event) => {
-      const cleaned = stripLeadingSpaces(event.target.value);
+      const cleaned = removeWhitespace(event.target.value);
+      setEmailAvailability(null);
+
+      if (
+        (formState.errors.email as { type?: string } | undefined)?.type ===
+        "server"
+      ) {
+        clearErrors("email");
+      }
 
       if (cleaned !== event.target.value) {
         event.target.value = cleaned;
@@ -291,7 +413,7 @@ export function AddTutor() {
       }
     },
     onBlur: (event) => {
-      setValue("email", event.target.value.trim(), {
+      setValue("email", removeWhitespace(event.target.value).toLowerCase(), {
         shouldValidate: true,
       });
     },
@@ -392,15 +514,49 @@ export function AddTutor() {
 
               <div className="space-y-2">
                 <Label htmlFor="email">Email *</Label>
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="e.g johndoe@gmail.com"
-                  {...emailRegister}
-                />
-                {formState.errors.email && (
-                  <p className="text-sm text-red-500">
+                <div className="relative">
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="e.g johndoe@gmail.com"
+                    autoComplete="email"
+                    className={`pr-10 ${
+                      formState.errors.email ? "border-red-500" : ""
+                    }`}
+                    {...emailRegister}
+                  />
+                  <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3">
+                    {isCheckingEmail ? (
+                      <Spinner className="text-gray-400" />
+                    ) : formState.errors.email ||
+                      emailAvailability === "unavailable" ? (
+                      <CircleX
+                        className="h-4 w-4 text-red-500"
+                        aria-hidden="true"
+                      />
+                    ) : emailAvailability === "available" ? (
+                      <CircleCheck
+                        className="h-4 w-4 text-green-600"
+                        aria-hidden="true"
+                      />
+                    ) : null}
+                  </span>
+                </div>
+                {formState.errors.email ? (
+                  <p className="min-h-4 text-sm leading-4 text-red-500">
                     {formState.errors.email.message}
+                  </p>
+                ) : isCheckingEmail ? (
+                  <p className="min-h-4 text-sm leading-4 text-gray-500">
+                    Checking email availability...
+                  </p>
+                ) : emailAvailability === "available" ? (
+                  <p className="min-h-4 text-sm leading-4 text-green-600">
+                    Email is available
+                  </p>
+                ) : (
+                  <p className="min-h-4 text-sm leading-4 text-muted-foreground">
+                    Enter a valid email address
                   </p>
                 )}
               </div>

--- a/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
+++ b/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
@@ -669,7 +669,7 @@ export function AddTutor() {
                     </p>
                   ) : watch("dateOfBirth") && !formState.errors.dateOfBirth ? (
                     <p className="text-sm text-muted-foreground">
-                      You must be at least 18 years old
+                      Calculated from your date of birth
                     </p>
                   ) : null}
                 </div>

--- a/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
+++ b/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
@@ -46,6 +46,7 @@ import {
   stripLeadingSpaces,
 } from "@/utils/form-normalizers";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Eye, EyeOff } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import {
   Controller,
@@ -69,6 +70,8 @@ const getMinimumAdultBirthDate = () => {
 
 export function AddTutor() {
   const [open, setOpen] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [createTutor, { isLoading }] = useCreateTutorMutation();
   const formId = "add-tutor-form";
   const maxTutorDateOfBirth = getMinimumAdultBirthDate();
@@ -186,6 +189,8 @@ export function AddTutor() {
   useEffect(() => {
     if (!open) {
       reset(initialTutorFormValues);
+      setShowPassword(false);
+      setShowConfirmPassword(false);
     }
   }, [open, reset]);
 
@@ -194,6 +199,8 @@ export function AddTutor() {
 
     if (!isOpen) {
       reset(initialTutorFormValues);
+      setShowPassword(false);
+      setShowConfirmPassword(false);
     }
   };
 
@@ -249,6 +256,8 @@ export function AddTutor() {
 
     if ("data" in result) {
       reset(initialTutorFormValues);
+      setShowPassword(false);
+      setShowConfirmPassword(false);
       toast.success("Tutor added successfully");
       setOpen(false);
     }
@@ -399,13 +408,32 @@ export function AddTutor() {
               <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
                 <div className="space-y-2">
                   <Label htmlFor="password">Password *</Label>
-                  <Input
-                    id="password"
-                    type="password"
-                    autoComplete="new-password"
-                    placeholder="Min 8 chars, letter & number"
-                    {...form.register("password")}
-                  />
+                  <div className="relative">
+                    <Input
+                      id="password"
+                      type={showPassword ? "text" : "password"}
+                      autoComplete="new-password"
+                      placeholder="Min 8 chars, letter & number"
+                      className="pr-10"
+                      {...form.register("password")}
+                    />
+                    <button
+                      type="button"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 transition-colors hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/30 dark:text-gray-400 dark:hover:text-gray-200"
+                      onClick={() => setShowPassword((value) => !value)}
+                      aria-label={
+                        showPassword ? "Hide password" : "Show password"
+                      }
+                      aria-controls="password"
+                      aria-pressed={showPassword}
+                    >
+                      {showPassword ? (
+                        <EyeOff className="h-4 w-4" aria-hidden="true" />
+                      ) : (
+                        <Eye className="h-4 w-4" aria-hidden="true" />
+                      )}
+                    </button>
+                  </div>
                   {formState.errors.password && (
                     <p className="text-sm text-red-500">
                       {formState.errors.password.message}
@@ -415,13 +443,36 @@ export function AddTutor() {
 
                 <div className="space-y-2">
                   <Label htmlFor="confirmPassword">Confirm Password *</Label>
-                  <Input
-                    id="confirmPassword"
-                    type="password"
-                    autoComplete="new-password"
-                    placeholder="Re-enter your password"
-                    {...form.register("confirmPassword")}
-                  />
+                  <div className="relative">
+                    <Input
+                      id="confirmPassword"
+                      type={showConfirmPassword ? "text" : "password"}
+                      autoComplete="new-password"
+                      placeholder="Re-enter your password"
+                      className="pr-10"
+                      {...form.register("confirmPassword")}
+                    />
+                    <button
+                      type="button"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 transition-colors hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500/30 dark:text-gray-400 dark:hover:text-gray-200"
+                      onClick={() =>
+                        setShowConfirmPassword((value) => !value)
+                      }
+                      aria-label={
+                        showConfirmPassword
+                          ? "Hide confirm password"
+                          : "Show confirm password"
+                      }
+                      aria-controls="confirmPassword"
+                      aria-pressed={showConfirmPassword}
+                    >
+                      {showConfirmPassword ? (
+                        <EyeOff className="h-4 w-4" aria-hidden="true" />
+                      ) : (
+                        <Eye className="h-4 w-4" aria-hidden="true" />
+                      )}
+                    </button>
+                  </div>
                   {formState.errors.confirmPassword && (
                     <p className="text-sm text-red-500">
                       {formState.errors.confirmPassword.message}

--- a/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
+++ b/src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx
@@ -660,8 +660,7 @@ export function AddTutor() {
                     id="age"
                     type="number"
                     {...form.register("age", { valueAsNumber: true })}
-                    readOnly
-                    disabled={!watch("dateOfBirth")}
+                    disabled
                   />
                   {formState.errors.age ? (
                     <p className="text-sm text-red-500">

--- a/src/app/(admin)/tutors/components/add-tutor/schema.ts
+++ b/src/app/(admin)/tutors/components/add-tutor/schema.ts
@@ -38,7 +38,7 @@ export const addTutorSchema = z.object({
         .regex(/^\d{4}-\d{2}-\d{2}$/, "Date of Birth must be in YYYY-MM-DD"),
     ),
 
-  gender: z.enum(TUTOR_GENDER_VALUES),
+  gender: z.enum(TUTOR_GENDER_VALUES, "Gender is required"),
   age: z
     .number()
     .int()
@@ -51,8 +51,8 @@ export const addTutorSchema = z.object({
 
   grades: z.array(z.string()).min(1, "Select at least one grade"),
   subjects: z.array(z.string()).min(1, "Select at least one subject"),
-  nationality: z.enum(NATIONALITY_VALUES),
-  race: z.enum(RACE_VALUES),
+  nationality: z.enum(NATIONALITY_VALUES, "Nationality is required"),
+  race: z.enum(RACE_VALUES, "Race is required"),
 
   classType: z
     .array(z.enum(CLASS_TYPE_VALUES))
@@ -68,7 +68,7 @@ export const addTutorSchema = z.object({
 
   yearsExperience: z.number().int().min(1, "Years of Experience are required").max(50),
 
-  highestEducation: z.enum(EDUCATION_VALUES_ADD),
+  highestEducation: z.enum(EDUCATION_VALUES_ADD, "Highest Education is required"),
 
   academicDetails: z.string().min(1, "Academic Details are required").max(1000),
   teachingSummary: z.string().min(1, "Teaching Summary is required").max(750),
@@ -132,7 +132,7 @@ export const initialTutorFormValues: AddTutorFormValues = {
   preferredLocations: [],
   tutorType: [],
   yearsExperience: 0,
-  highestEducation: "Undergraduate",
+  highestEducation: "" as AddTutorFormValues["highestEducation"],
   academicDetails: "",
   teachingSummary: "",
   studentResults: "",

--- a/src/app/(admin)/tutors/components/edit-tutor/EditTutor.tsx
+++ b/src/app/(admin)/tutors/components/edit-tutor/EditTutor.tsx
@@ -609,6 +609,13 @@ export function EditTutor({ id }: EditTutorProps) {
                       {formState.errors.age.message}
                     </p>
                   )}
+                  {!formState.errors.age &&
+                  watch("dateOfBirth") &&
+                  !formState.errors.dateOfBirth ? (
+                    <p className="text-sm text-muted-foreground">
+                      Calculated from your date of birth
+                    </p>
+                  ) : null}
                 </div>
               </div>
 

--- a/src/store/api/endpoints.ts
+++ b/src/store/api/endpoints.ts
@@ -18,6 +18,7 @@ export const Endpoints = {
   Admins: "/v1/users/admins",
   ChangePassword: "/v1/users/change-password",
   FindATutor: "/v1/tutors",
+  FindATutorEmailAvailability: "/v1/tutors/email-availability",
   TuitionRates: "/v1/tuitionRates",
   Levels: "/v1/levels",
   TuitionAssignments: "/v1/tuition-assignments",

--- a/src/store/api/splits/tutors/index.ts
+++ b/src/store/api/splits/tutors/index.ts
@@ -2,7 +2,11 @@
 import { AddTutorFormValues } from "@/app/(admin)/tutors/components/add-tutor/schema";
 import { UpdateTutorSchema } from "@/app/(admin)/tutors/components/edit-tutor/schema";
 import { FetchTutorsRequest } from "@/types/request-types";
-import { PaginatedResponse, Tutor } from "@/types/response-types";
+import {
+  PaginatedResponse,
+  Tutor,
+  TutorEmailAvailabilityResponse,
+} from "@/types/response-types";
 import { baseApi } from "../..";
 import { Endpoints } from "../../endpoints";
 
@@ -26,6 +30,16 @@ export const TutorsApi = baseApi.injectEndpoints({
         method: "GET",
       }),
       providesTags: ["FindATutor"],
+    }),
+
+    getTutorEmailAvailability: build.query<
+      TutorEmailAvailabilityResponse,
+      string
+    >({
+      query: (email) => ({
+        url: `${Endpoints.FindATutorEmailAvailability}?email=${encodeURIComponent(email)}`,
+        method: "GET",
+      }),
     }),
 
     createTutor: build.mutation<Tutor, Omit<AddTutorFormValues, "confirmPassword">>({
@@ -103,6 +117,7 @@ export const {
   useFetchTutorsQuery,
   useFetchTutorByIdQuery,
   useLazyFetchTutorByIdQuery,
+  useLazyGetTutorEmailAvailabilityQuery,
   useCreateTutorMutation,
   useUpdateTutorMutation,
   useUpdateTutorStatusMutation,

--- a/src/types/response-types.ts
+++ b/src/types/response-types.ts
@@ -337,6 +337,11 @@ export type Tutor = BaseEntity & {
   certificatesAndQualifications: CertificateItem[];
 };
 
+export type TutorEmailAvailabilityResponse = {
+  available: boolean;
+  message: string;
+};
+
 export type RequestTutorTutor = {
   _id: string;
   subject: string;


### PR DESCRIPTION
## Summary
This PR fixes multiple Admin Portal UI and validation issues related to Add/Edit Tutor forms and profile status styling.

## Changes

### Frontend
* Added password visibility toggles for Password and Confirm Password in Add Tutor form
* Added duplicate email availability validation in Add Tutor form
* Added email availability UI feedback: checking, available, and already exists states
* Updated required error messages for Gender, Nationality, and Race
* Made Highest Education unselected by default in Add Tutor form
* Updated Age helper text in Add Tutor and Edit Tutor forms
* Styled Add Tutor Age field as disabled/non-editable
* Updated profile status badge colors:
  * Approved: green
  * Pending: yellow
  * Other statuses: red

### Backend
* No backend changes in this PR

## Files Changed
* `src/app/(admin)/tutors/components/add-tutor/AddTutor.tsx`
* `src/app/(admin)/tutors/components/add-tutor/schema.ts`
* `src/app/(admin)/tutors/components/edit-tutor/EditTutor.tsx`
* `src/store/api/endpoints.ts`
* `src/store/api/splits/tutors/index.ts`
* `src/types/response-types.ts`
* `src/app/(admin)/(others-pages)/profile/components/UserMetaCard.tsx`

## Root Cause
* Missing UI states and validation handling in Add/Edit Tutor forms caused confusing or incomplete feedback for admins.
* Duplicate email validation only happened after form submission and did not mirror the tutor registration flow.
* Profile status badge styling did not handle pending status separately.

## Result
* Admins now get clearer validation feedback while creating or editing tutors.
* Duplicate tutor emails are blocked with `Email already exists`.
* Age fields clearly show calculated/non-editable behavior.
* Profile status colors are easier to identify visually.
