### PR TITLE
fix: assign tutor location matching and admin account security (TM-886)

### DIFF
--- a/src/app/(admin)/(others-pages)/profile/components/AccountSecurity.tsx
+++ b/src/app/(admin)/(others-pages)/profile/components/AccountSecurity.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import InputPassword from "@/components/shared/input-password";
+import { Button } from "@/components/ui/button";
+import { useAuthContext } from "@/context";
+import {
+  PASSWORD_LETTER_NUMBER_MSG,
+  PASSWORD_LETTER_NUMBER_REGEX,
+  PASSWORD_MAX,
+  PASSWORD_MIN,
+  PASSWORD_TOO_LONG,
+  PASSWORD_TOO_SHORT,
+} from "@/configs/password";
+import { useUpdateUserPasswordMutation } from "@/store/api/splits/users";
+import { getErrorInApiResult } from "@/utils/api";
+import { removeWhitespace } from "@/utils/form-normalizers";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { ChangeEvent, KeyboardEvent } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import toast from "react-hot-toast";
+import { z } from "zod";
+
+const passwordSchema = z
+  .object({
+    currentPassword: z.preprocess(
+      removeWhitespace,
+      z.string().min(1, { message: "Current password is required" }),
+    ),
+    newPassword: z.preprocess(
+      removeWhitespace,
+      z
+        .string()
+        .min(PASSWORD_MIN, { message: PASSWORD_TOO_SHORT })
+        .max(PASSWORD_MAX, { message: PASSWORD_TOO_LONG })
+        .regex(PASSWORD_LETTER_NUMBER_REGEX, { message: PASSWORD_LETTER_NUMBER_MSG }),
+    ),
+    confirmPassword: z.preprocess(
+      removeWhitespace,
+      z.string().min(PASSWORD_MIN, { message: PASSWORD_TOO_SHORT }),
+    ),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Confirm Password must match New Password",
+    path: ["confirmPassword"],
+  });
+
+type PasswordSchema = z.infer<typeof passwordSchema>;
+
+const initialValues: PasswordSchema = {
+  currentPassword: "",
+  newPassword: "",
+  confirmPassword: "",
+};
+
+const preventWhitespaceKey = (event: KeyboardEvent<HTMLInputElement>) => {
+  if (/\s/.test(event.key)) event.preventDefault();
+};
+
+export default function AccountSecurity() {
+  const { user: authUser } = useAuthContext();
+  const [updateUserPassword, { isLoading }] = useUpdateUserPasswordMutation();
+
+  const form = useForm<PasswordSchema>({
+    resolver: zodResolver(passwordSchema),
+    defaultValues: initialValues,
+    mode: "onChange",
+  });
+
+  const { isDirty, isValid } = form.formState;
+  const currentPassword = form.watch("currentPassword");
+  const newPassword = form.watch("newPassword");
+  const confirmPassword = form.watch("confirmPassword");
+
+  const areAllFieldsFilled =
+    !!currentPassword?.trim() && !!newPassword?.trim() && !!confirmPassword?.trim();
+
+  const isButtonDisabled = !isDirty || !areAllFieldsFilled || !isValid || isLoading;
+
+  const sanitize =
+    (field: keyof PasswordSchema) => (event: ChangeEvent<HTMLInputElement>) => {
+      const noSpaces = removeWhitespace(event.target.value);
+      if (noSpaces !== event.target.value) event.target.value = noSpaces;
+      form.setValue(field, noSpaces, { shouldValidate: true, shouldDirty: true });
+    };
+
+  const onSubmit = async (data: PasswordSchema) => {
+    if (!authUser?.id) return;
+
+    const result = await updateUserPassword({
+      id: authUser.id,
+      payload: {
+        currentPassword: data.currentPassword,
+        newPassword: data.newPassword,
+      },
+    });
+
+    const error = getErrorInApiResult(result);
+    if (error) return toast.error(error);
+
+    toast.success("Password updated successfully");
+    form.reset();
+  };
+
+  return (
+    <div className="p-5 border border-gray-200 rounded-2xl dark:border-gray-800 lg:p-6">
+      <h3 className="mb-2 text-lg font-semibold text-gray-800 dark:text-white/90">
+        Account Security
+      </h3>
+      <p className="mb-5 text-sm text-gray-500 dark:text-gray-400">
+        Change your password using your current password for verification.
+      </p>
+
+      <FormProvider {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <div className="grid max-w-xl grid-cols-1 gap-4 sm:gap-5">
+            <InputPassword
+              label="Current password *"
+              name="currentPassword"
+              placeholder="Enter current password"
+              onKeyDown={preventWhitespaceKey}
+              onChange={sanitize("currentPassword")}
+            />
+            <InputPassword
+              label="New password *"
+              name="newPassword"
+              placeholder="Enter new password"
+              onKeyDown={preventWhitespaceKey}
+              onChange={sanitize("newPassword")}
+            />
+            <InputPassword
+              label="Confirm password *"
+              name="confirmPassword"
+              placeholder="Re-enter new password"
+              onKeyDown={preventWhitespaceKey}
+              onChange={sanitize("confirmPassword")}
+            />
+          </div>
+
+          <div className="mt-4 sm:mt-5">
+            <Button
+              type="submit"
+              disabled={isButtonDisabled}
+              isLoading={isLoading}
+              className="bg-blue-700 text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Change Password
+            </Button>
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+}

--- a/src/app/(admin)/(others-pages)/profile/page.tsx
+++ b/src/app/(admin)/(others-pages)/profile/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import AccountSecurity from "./components/AccountSecurity";
 import UserInfoCard from "./components/UserInfoCard";
 import UserMetaCard from "./components/UserMetaCard";
 
@@ -10,13 +11,14 @@ export const metadata: Metadata = {
 export default function Profile() {
   return (
     <div>
-      <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03] lg:p-6">
+      <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/3 lg:p-6">
         <h3 className="mb-5 text-lg font-semibold text-gray-800 dark:text-white/90 lg:mb-7">
           Profile
         </h3>
         <div className="space-y-6">
           <UserMetaCard />
           <UserInfoCard />
+          <AccountSecurity />
         </div>
       </div>
     </div>

--- a/src/app/(admin)/request-tutor/TutorsList.tsx
+++ b/src/app/(admin)/request-tutor/TutorsList.tsx
@@ -463,7 +463,7 @@ export default function RequestForTutorsList() {
             row={{
               id: row.id,
               grade: getGradeDisplayValue(row.grade),
-              district: getSafeValue(row.district, ""),
+              district: getSafeValue(row.city, ""),
               medium: getSafeValue(row.medium, ""),
               tutors: getSafeTutorBlocks(row.tutors).map((t) => ({
                 _id: t._id,

--- a/src/store/api/splits/users/index.ts
+++ b/src/store/api/splits/users/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { CreateUserSchema } from "@/app/(admin)/users/all-users/components/add-user/schema";
-import { FetchUserRequest, UpdateUserRequest } from "@/types/request-types";
-import { PaginatedResponse, Users } from "@/types/response-types";
+import { FetchUserRequest, UpdatePasswordRequest, UpdateUserRequest } from "@/types/request-types";
+import { PaginatedResponse, UpdatePasswordResponse, Users } from "@/types/response-types";
 import { baseApi } from "../..";
 import { Endpoints } from "../../endpoints";
 
@@ -86,6 +86,14 @@ export const UsersApi = baseApi.injectEndpoints({
         "FindATutor",
       ],
     }),
+
+    updateUserPassword: build.mutation<UpdatePasswordResponse, UpdatePasswordRequest>({
+      query: ({ id, payload }) => ({
+        url: `${Endpoints.ChangePassword}/${id}`,
+        method: "PATCH",
+        body: payload,
+      }),
+    }),
   }),
   overrideExisting: false,
 });
@@ -98,4 +106,5 @@ export const {
   useUpdateUserMutation,
   useDeleteUserMutation,
   useSendUserTempPasswordMutation,
+  useUpdateUserPasswordMutation,
 } = UsersApi;


### PR DESCRIPTION
## Summary

- **Assign Tutor location fix** — Fixed tutor location filtering in Assign Tutors dialog. 
  `row.district` was always empty (API no longer returns district), causing all tutors to 
  pass the location check regardless of city. Replaced with `row.city`.
- **TM-886** — Added Account Security (Change Password) section to Admin User Profile page. 
  Includes Current/New/Confirm password fields with show/hide toggle, Zod validation, 
  whitespace prevention, and `PATCH /v1/users/change-password/{id}` API integration.

## Test plan

- [ ] Assign Tutors on a physical class request — only tutors with matching city in 
      preferredLocations should appear in the dropdown
- [ ] Admin profile page — Account Security section is visible below Location Information
- [ ] Change password with wrong current password — shows error from API
- [ ] Change password with mismatched confirm password — shows validation error
- [ ] Successful password change — toast success and form resets